### PR TITLE
feat: send cancel events to client surfaces earlier

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -167,6 +167,7 @@ bool CGestures::onTouchDown(wlr_touch_down_event* ev) {
 
     if (!eventForwardingInhibited() &&
         g_pInputManager->m_sTouchData.touchFocusSurface) {
+        // remember which surfaces were touched, to later send cancel events
         const auto surface = g_pInputManager->m_sTouchData.touchFocusSurface;
         const auto TOUCHED =
             std::find(touchedSurfaces.begin(), touchedSurfaces.end(), surface);

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -239,6 +239,10 @@ bool CGestures::onTouchMove(wlr_touch_motion_event* ev) {
     if (g_pCompositor->m_sSeat.exclusiveClient) // lock screen, I think
         return false;
 
+    if (this->dragGestureIsActive()) {
+        this->emulateSwipeUpdate(0);
+    }
+
     auto pos = wlrTouchEventPositionAsPixels(ev->x, ev->y);
 
     const wf::touch::gesture_event_t gesture_event = {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -108,8 +108,7 @@ bool CGestures::handleGesture(const CompletedGesture& gev) {
             continue;
 
         DISPATCHER->second(k.arg);
-        m_bDispatcherFound = true;
-        found              = true;
+        found = true;
     }
     return found;
 }
@@ -146,7 +145,6 @@ void CGestures::handleWorkspaceSwipe(const CompletedGesture& gev) {
             // FIXME time arg of @emulateSwipeBegin should probably be assigned
             // something useful (though its not really used later)
             this->emulateSwipeBegin(0);
-            m_bDispatcherFound = true;
         }
     }
 }

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -73,8 +73,7 @@ void CGestures::emulateSwipeUpdate(uint32_t time) {
 
 bool CGestures::handleGesture(const CompletedGesture& gev) {
     if (gev.type == GESTURE_TYPE_SWIPE_HOLD) {
-        this->handleWorkspaceSwipe(gev);
-        return true;
+        return this->handleWorkspaceSwipe(gev);
     }
     if (gev.type == GESTURE_TYPE_SWIPE && dragGestureIsActive()) {
         this->emulateSwipeEnd(0, false);
@@ -121,7 +120,7 @@ void CGestures::handleCancelledGesture() {
     this->emulateSwipeEnd(0, false);
 }
 
-void CGestures::handleWorkspaceSwipe(const CompletedGesture& gev) {
+bool CGestures::handleWorkspaceSwipe(const CompletedGesture& gev) {
     static auto* const PWORKSPACEFINGERS =
         &HyprlandAPI::getConfigValue(
              PHANDLE, "plugin:touch_gestures:workspace_swipe_fingers")
@@ -145,8 +144,11 @@ void CGestures::handleWorkspaceSwipe(const CompletedGesture& gev) {
             // FIXME time arg of @emulateSwipeBegin should probably be assigned
             // something useful (though its not really used later)
             this->emulateSwipeBegin(0);
+            return true;
         }
     }
+
+    return false;
 }
 
 void CGestures::sendCancelEventsToWindows() {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -15,8 +15,7 @@ CGestures::CGestures() {
                                      "plugin:touch_gestures:sensitivity")
              ->floatValue;
 
-    addMultiFingerDragGesture(PSENSITIVITY);
-    addMultiFingerSwipeThenLiftoffGesture(PSENSITIVITY);
+    addMultiFingerGesture(PSENSITIVITY);
     addEdgeSwipeGesture(PSENSITIVITY);
 }
 

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -213,11 +213,7 @@ bool CGestures::onTouchDown(wlr_touch_down_event* ev) {
 
     IGestureManager::onTouchDown(gesture_event);
 
-    if (m_bDispatcherFound) {
-        m_bDispatcherFound = false;
-        return true;
-    }
-    return false;
+    return this->eventForwardingInhibited();
 }
 
 bool CGestures::onTouchUp(wlr_touch_up_event* ev) {
@@ -247,11 +243,7 @@ bool CGestures::onTouchUp(wlr_touch_up_event* ev) {
         emulateSwipeEnd(ev->time_msec, false);
     }
 
-    if (m_bDispatcherFound) {
-        m_bDispatcherFound = false;
-        return true;
-    }
-    return false;
+    return this->eventForwardingInhibited();
 }
 
 bool CGestures::onTouchMove(wlr_touch_motion_event* ev) {
@@ -274,11 +266,7 @@ bool CGestures::onTouchMove(wlr_touch_motion_event* ev) {
         emulateSwipeUpdate(ev->time_msec);
     }
 
-    if (m_bDispatcherFound) {
-        m_bDispatcherFound = false;
-        return true;
-    }
-    return false;
+    return this->eventForwardingInhibited();
 }
 
 SMonitorArea CGestures::getMonitorArea() const {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -210,10 +210,6 @@ bool CGestures::onTouchDown(wlr_touch_down_event* ev) {
     const auto& geometry = m_pLastTouchedMonitor->vecSize;
     m_sMonitorArea       = {position.x, position.y, geometry.x, geometry.y};
 
-    if (m_bWorkspaceSwipeActive) {
-        emulateSwipeEnd(ev->time_msec, false);
-    }
-
     // NOTE @wlr_touch_down_event.x and y uses a number between 0 and 1 to
     // represent "how many percent of screen" whereas
     // @wf::touch::gesture_event_t uses PIXELS as unit
@@ -252,11 +248,6 @@ bool CGestures::onTouchUp(wlr_touch_up_event* ev) {
     };
 
     IGestureManager::onTouchUp(gesture_event);
-
-    // TODO where do I put this, before or after IGestureManager::onTouchUp...?
-    if (m_bWorkspaceSwipeActive) {
-        emulateSwipeEnd(ev->time_msec, false);
-    }
 
     return this->eventForwardingInhibited();
 }

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -71,16 +71,6 @@ void CGestures::emulateSwipeUpdate(uint32_t time) {
     m_vGestureLastCenter = currentCenter;
 }
 
-// TODO: remove
-std::vector<int> CGestures::getAllFingerIds() {
-    auto ret = std::vector<int>();
-    for (const auto& finger : m_sGestureState.fingers) {
-        ret.emplace_back(finger.first);
-    }
-
-    return ret;
-}
-
 bool CGestures::handleGesture(const CompletedGesture& gev) {
     if (gev.type == GESTURE_TYPE_SWIPE_HOLD) {
         this->handleWorkspaceSwipe(gev);

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -33,16 +33,13 @@ void CGestures::emulateSwipeBegin(uint32_t time) {
                                       .fingers   = (uint32_t)*PSWIPEFINGERS};
     g_pInputManager->onSwipeBegin(&emulated_swipe);
 
-    m_vGestureLastCenter    = m_sGestureState.get_center().origin;
-    m_bWorkspaceSwipeActive = true;
+    m_vGestureLastCenter = m_sGestureState.get_center().origin;
 }
 
 void CGestures::emulateSwipeEnd(uint32_t time, bool cancelled) {
     auto emulated_swipe = wlr_pointer_swipe_end_event{
         .pointer = nullptr, .time_msec = time, .cancelled = cancelled};
     g_pInputManager->onSwipeEnd(&emulated_swipe);
-
-    m_bWorkspaceSwipeActive = false;
 }
 
 void CGestures::emulateSwipeUpdate(uint32_t time) {
@@ -74,6 +71,7 @@ void CGestures::emulateSwipeUpdate(uint32_t time) {
     m_vGestureLastCenter = currentCenter;
 }
 
+// TODO: remove
 std::vector<int> CGestures::getAllFingerIds() {
     auto ret = std::vector<int>();
     for (const auto& finger : m_sGestureState.fingers) {
@@ -221,9 +219,7 @@ bool CGestures::onTouchDown(wlr_touch_down_event* ev) {
         .pos    = pos,
     };
 
-    IGestureManager::onTouchDown(gesture_event);
-
-    return this->eventForwardingInhibited();
+    return IGestureManager::onTouchDown(gesture_event);
 }
 
 bool CGestures::onTouchUp(wlr_touch_up_event* ev) {
@@ -246,9 +242,7 @@ bool CGestures::onTouchUp(wlr_touch_up_event* ev) {
         .pos    = {lift_off_pos.x, lift_off_pos.y},
     };
 
-    IGestureManager::onTouchUp(gesture_event);
-
-    return this->eventForwardingInhibited();
+    return IGestureManager::onTouchUp(gesture_event);
 }
 
 bool CGestures::onTouchMove(wlr_touch_motion_event* ev) {
@@ -264,14 +258,7 @@ bool CGestures::onTouchMove(wlr_touch_motion_event* ev) {
         .pos    = pos,
     };
 
-    IGestureManager::onTouchMove(gesture_event);
-
-    // TODO where do I put this
-    if (m_bWorkspaceSwipeActive) {
-        emulateSwipeUpdate(ev->time_msec);
-    }
-
-    return this->eventForwardingInhibited();
+    return IGestureManager::onTouchMove(gesture_event);
 }
 
 SMonitorArea CGestures::getMonitorArea() const {

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -19,10 +19,6 @@ class CGestures : public IGestureManager {
     // @return whether a gesture was triggered after this event
     bool onTouchMove(wlr_touch_motion_event*);
 
-    void emulateSwipeBegin(uint32_t time);
-    void emulateSwipeEnd(uint32_t time, bool cancelled);
-    void emulateSwipeUpdate(uint32_t time);
-
   protected:
     SMonitorArea getMonitorArea() const override;
     bool handleGesture(const CompletedGesture& gev) override;
@@ -36,6 +32,9 @@ class CGestures : public IGestureManager {
 
     // for workspace swipe
     wf::touch::point_t m_vGestureLastCenter;
+    void emulateSwipeBegin(uint32_t time);
+    void emulateSwipeEnd(uint32_t time, bool cancelled);
+    void emulateSwipeUpdate(uint32_t time);
 
     void addDefaultGestures();
     wf::touch::point_t wlrTouchEventPositionAsPixels(double x, double y) const;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -36,7 +36,6 @@ class CGestures : public IGestureManager {
     void emulateSwipeEnd(uint32_t time, bool cancelled);
     void emulateSwipeUpdate(uint32_t time);
 
-    void addDefaultGestures();
     wf::touch::point_t wlrTouchEventPositionAsPixels(double x, double y) const;
     void handleWorkspaceSwipe(const CompletedGesture& gev);
 

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 #include <wayfire/touch/touch.hpp>
 
-class CGestures final : public IGestureManager {
+class CGestures : public IGestureManager {
   public:
     CGestures();
     // @return whether a gesture was triggered after this event
@@ -22,8 +22,6 @@ class CGestures final : public IGestureManager {
     void emulateSwipeBegin(uint32_t time);
     void emulateSwipeEnd(uint32_t time, bool cancelled);
     void emulateSwipeUpdate(uint32_t time);
-
-    std::vector<int> getAllFingerIds();
 
   protected:
     SMonitorArea getMonitorArea() const override;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -39,7 +39,7 @@ class CGestures : public IGestureManager {
     void emulateSwipeUpdate(uint32_t time);
 
     wf::touch::point_t wlrTouchEventPositionAsPixels(double x, double y) const;
-    void handleWorkspaceSwipe(const CompletedGesture& gev);
+    bool handleWorkspaceSwipe(const CompletedGesture& gev);
 
     void sendCancelEventsToWindows() override;
 };

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 #include <wayfire/touch/touch.hpp>
 
-class CGestures : public IGestureManager {
+class CGestures final : public IGestureManager {
   public:
     CGestures();
     // @return whether a gesture was triggered after this event
@@ -37,7 +37,6 @@ class CGestures : public IGestureManager {
     SMonitorArea m_sMonitorArea;
 
     // for workspace swipe
-    bool m_bWorkspaceSwipeActive = false;
     wf::touch::point_t m_vGestureLastCenter;
 
     void addDefaultGestures();

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -10,13 +10,16 @@
 class CGestures : public IGestureManager {
   public:
     CGestures();
-    // @return whether a gesture was triggered after this event
+    // @return whether this touch event should be blocked from forwarding to the
+    // client window/surface
     bool onTouchDown(wlr_touch_down_event*);
 
-    // @return whether a gesture was triggered after this event
+    // @return whether this touch event should be blocked from forwarding to the
+    // client window/surface
     bool onTouchUp(wlr_touch_up_event*);
 
-    // @return whether a gesture was triggered after this event
+    // @return whether this touch event should be blocked from forwarding to the
+    // client window/surface
     bool onTouchMove(wlr_touch_motion_event*);
 
   protected:

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -31,6 +31,7 @@ class CGestures : public IGestureManager {
     void handleCancelledGesture() override{};
 
   private:
+    std::vector<wlr_surface*> touchedSurfaces;
     bool m_bDispatcherFound = false;
     CMonitor* m_pLastTouchedMonitor;
     SMonitorArea m_sMonitorArea;
@@ -42,6 +43,8 @@ class CGestures : public IGestureManager {
     void addDefaultGestures();
     wf::touch::point_t wlrTouchEventPositionAsPixels(double x, double y) const;
     void handleWorkspaceSwipe(const CompletedGesture& gev);
+
+    void sendCancelEventsToWindows() override;
 };
 
 inline std::unique_ptr<CGestures> g_pGestureManager;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -27,8 +27,8 @@ class CGestures : public IGestureManager {
 
   protected:
     SMonitorArea getMonitorArea() const override;
-    void handleGesture(const CompletedGesture& gev) override;
-    void handleCancelledGesture() override{};
+    bool handleGesture(const CompletedGesture& gev) override;
+    void handleCancelledGesture() override;
 
   private:
     std::vector<wlr_surface*> touchedSurfaces;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -29,7 +29,6 @@ class CGestures : public IGestureManager {
 
   private:
     std::vector<wlr_surface*> touchedSurfaces;
-    bool m_bDispatcherFound = false;
     CMonitor* m_pLastTouchedMonitor;
     SMonitorArea m_sMonitorArea;
 

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -106,6 +106,26 @@ CMultiAction::update_state(const wf::touch::gesture_state_t& state,
 }
 
 wf::touch::action_status_t
+MultiFingerDownAction::update_state(const wf::touch::gesture_state_t& state,
+                                    const wf::touch::gesture_event_t& event) {
+    if (event.time - this->start_time > this->get_duration()) {
+        // TODO
+        return wf::touch::ACTION_STATUS_CANCELLED;
+    }
+
+    if (event.type == wf::touch::EVENT_TYPE_TOUCH_UP) {
+        return wf::touch::ACTION_STATUS_CANCELLED;
+    }
+
+    if (event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN &&
+        state.fingers.size() >= 3) {
+        return wf::touch::ACTION_STATUS_COMPLETED;
+    }
+
+    return wf::touch::ACTION_STATUS_RUNNING;
+}
+
+wf::touch::action_status_t
 LiftoffAction::update_state(const wf::touch::gesture_state_t& state,
                             const wf::touch::gesture_event_t& event) {
 
@@ -122,6 +142,13 @@ LiftoffAction::update_state(const wf::touch::gesture_state_t& state,
     }
 
     return wf::touch::ACTION_STATUS_RUNNING;
+}
+
+wf::touch::action_status_t
+CallbackAction::update_state(const wf::touch::gesture_state_t& state,
+                             const wf::touch::gesture_event_t& event) {
+    this->callback();
+    return wf::touch::ACTION_STATUS_COMPLETED;
 }
 
 void IGestureManager::updateGestures(const wf::touch::gesture_event_t& ev) {

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -225,7 +225,7 @@ void IGestureManager::addTouchGesture(
 }
 
 // Adds a Multi-fingered swipe:
-// * inhibits events to client windows/surfaces when more enough fingers touch
+// * inhibits events to client windows/surfaces when enough fingers touch
 //   down within a short duration.
 // * emits a GESTURE_TYPE_SWIPE_HOLD event once fingers moved over the
 //   threshold.

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -107,7 +107,6 @@ wf::touch::action_status_t
 MultiFingerDownAction::update_state(const wf::touch::gesture_state_t& state,
                                     const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > this->get_duration()) {
-        // TODO
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
 

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -227,61 +227,6 @@ void IGestureManager::addTouchGesture(
     m_vGestures.emplace_back(std::move(gesture));
 }
 
-// Multi fingered swipe, triggers once whenever you swipe more than the
-// threshold.
-void IGestureManager::addMultiFingerDragGesture(const float* sensitivity) {
-    auto swipe = std::make_unique<CMultiAction>(SWIPE_INCORRECT_DRAG_TOLERANCE,
-                                                sensitivity);
-    // swipe->set_duration(GESTURE_BASE_DURATION * *sensitivity);
-
-    // FIXME memory management be damned
-    auto swipe_ptr = swipe.get();
-
-    std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
-    swipe_actions.emplace_back(std::move(swipe));
-
-    auto ack = [swipe_ptr, this]() {
-        const auto gesture = CompletedGesture{GESTURE_TYPE_SWIPE_HOLD,
-                                              swipe_ptr->target_direction,
-                                              swipe_ptr->finger_count};
-        this->handleGesture(gesture);
-    };
-    auto cancel = [this]() { this->handleCancelledGesture(); };
-
-    addTouchGesture(std::make_unique<wf::touch::gesture_t>(
-        std::move(swipe_actions), ack, cancel));
-}
-
-// Multi fingered swipe, triggers on liftoff
-//
-// TODO rename
-void IGestureManager::addMultiFingerSwipeThenLiftoffGesture(
-    const float* sensitivity) {
-    auto swipe = std::make_unique<CMultiAction>(SWIPE_INCORRECT_DRAG_TOLERANCE,
-                                                sensitivity);
-    swipe->set_duration(GESTURE_BASE_DURATION);
-    auto swipe_liftoff = std::make_unique<LiftoffAction>();
-    swipe_liftoff->set_duration(GESTURE_BASE_DURATION / 2);
-
-    // FIXME memory management be damned
-    auto swipe_ptr = swipe.get();
-
-    std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
-    swipe_actions.emplace_back(std::move(swipe));
-    swipe_actions.emplace_back(std::move(swipe_liftoff));
-
-    auto ack = [swipe_ptr, this]() {
-        const auto gesture =
-            CompletedGesture{GESTURE_TYPE_SWIPE, swipe_ptr->target_direction,
-                             swipe_ptr->finger_count};
-        this->handleGesture(gesture);
-    };
-    auto cancel = [this]() { this->handleCancelledGesture(); };
-
-    addTouchGesture(std::make_unique<wf::touch::gesture_t>(
-        std::move(swipe_actions), ack, cancel));
-}
-
 // Adds a Multi-fingered swipe:
 // * inhibits events to client windows/surfaces when more enough fingers touch
 //   down within a short duration.

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -170,8 +170,8 @@ void IGestureManager::updateGestures(const wf::touch::gesture_event_t& ev) {
 
 void IGestureManager::cancelTouchEventsOnAllWindows() {
     if (!this->inhibitTouchEvents) {
-        this->sendCancelEventsToWindows();
         this->inhibitTouchEvents = true;
+        this->sendCancelEventsToWindows();
     }
 }
 

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -278,6 +278,7 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
         std::move(swipe_actions), ack, cancel));
 }
 
+// TODO: fix duration, do not depend on sensitivity
 void IGestureManager::addEdgeSwipeGesture(const float* sensitivity) {
     // Edge swipe needs a quick release to be considered edge swipe
     auto edge = std::make_unique<CMultiAction>(MAX_SWIPE_DISTANCE, sensitivity);

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -115,7 +115,7 @@ MultiFingerDownAction::update_state(const wf::touch::gesture_state_t& state,
     }
 
     if (event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN &&
-        state.fingers.size() >= 3) {
+        state.fingers.size() >= SEND_CANCEL_EVENT_FINGER_COUNT) {
         this->callback();
         return wf::touch::ACTION_STATUS_COMPLETED;
     }

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -151,11 +151,14 @@ CallbackAction::update_state(const wf::touch::gesture_state_t& state,
 }
 
 void IGestureManager::updateGestures(const wf::touch::gesture_event_t& ev) {
+    if (m_sGestureState.fingers.size() == 1 &&
+        ev.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) {
+        this->inhibitTouchEvents = false;
+        this->dragGestureActive  = false;
+    }
     for (auto& gesture : m_vGestures) {
         if (m_sGestureState.fingers.size() == 1 &&
             ev.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) {
-            this->inhibitTouchEvents = false;
-            this->dragGestureActive  = false;
             gesture->reset(ev.time);
         }
 

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -55,11 +55,6 @@ std::string CompletedGesture::to_string() const {
     return bind;
 }
 
-// The action is completed if any number of fingers is moved enough.
-//
-// This action should be followed by another that completes upon lifting a
-// finger to achieve a gesture that completes after a multi-finger swipe is done
-// and lifted.
 wf::touch::action_status_t
 CMultiAction::update_state(const wf::touch::gesture_state_t& state,
                            const wf::touch::gesture_event_t& event) {
@@ -249,9 +244,9 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
         if (this->dragGestureActive) {
             return;
         }
-        const auto gesture = CompletedGesture{GESTURE_TYPE_SWIPE_HOLD,
-                                              swipe_ptr->target_direction,
-                                              swipe_ptr->finger_count};
+        const auto gesture = CompletedGesture{
+            GESTURE_TYPE_SWIPE_HOLD, swipe_ptr->target_direction,
+            static_cast<int>(this->m_sGestureState.fingers.size())};
 
         this->dragGestureActive = this->handleGesture(gesture);
     };
@@ -267,9 +262,9 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
     swipe_actions.emplace_back(std::move(swipe_liftoff));
 
     auto ack = [swipe_ptr, this]() {
-        const auto gesture =
-            CompletedGesture{GESTURE_TYPE_SWIPE, swipe_ptr->target_direction,
-                             swipe_ptr->finger_count};
+        const auto gesture = CompletedGesture{
+            GESTURE_TYPE_SWIPE, swipe_ptr->target_direction,
+            static_cast<int>(this->m_sGestureState.fingers.size())};
         this->handleGesture(gesture);
     };
     auto cancel = [this]() { this->handleCancelledGesture(); };

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -183,19 +183,19 @@ bool IGestureManager::onTouchDown(const wf::touch::gesture_event_t& ev) {
     // gestures
     m_sGestureState.update(ev);
     updateGestures(ev);
-    return false;
+    return this->eventForwardingInhibited();
 }
 
 bool IGestureManager::onTouchUp(const wf::touch::gesture_event_t& ev) {
     updateGestures(ev);
     m_sGestureState.update(ev);
-    return false;
+    return this->eventForwardingInhibited();
 }
 
 bool IGestureManager::onTouchMove(const wf::touch::gesture_event_t& ev) {
     updateGestures(ev);
     m_sGestureState.update(ev);
-    return false;
+    return this->eventForwardingInhibited();
 }
 
 gestureDirection IGestureManager::find_swipe_edges(wf::touch::point_t point) {

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -229,7 +229,8 @@ void IGestureManager::addTouchGesture(
 //   down within a short duration.
 // * emits a GESTURE_TYPE_SWIPE_HOLD event once fingers moved over the
 //   threshold.
-// * emits a GESTURE_TYPE_SWIPE event once a finger is lifted
+// * further emits a GESTURE_TYPE_SWIPE event if the SWIPE_HOLD event was
+//   emitted and once a finger is lifted
 void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
     auto multi_down = std::make_unique<MultiFingerDownAction>(
         [this]() { this->cancelTouchEventsOnAllWindows(); });

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -159,6 +159,7 @@ void IGestureManager::updateGestures(const wf::touch::gesture_event_t& ev) {
         if (m_sGestureState.fingers.size() == 1 &&
             ev.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) {
             this->inhibitTouchEvents = false;
+            this->dragGestureActive  = false;
             gesture->reset(ev.time);
         }
 
@@ -309,7 +310,7 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
     auto swipe_begin = std::make_unique<CallbackAction>(swipe_begin_callback);
 
     auto swipe_liftoff = std::make_unique<LiftoffAction>();
-    swipe_liftoff->set_duration(GESTURE_BASE_DURATION / 2);
+    // swipe_liftoff->set_duration(GESTURE_BASE_DURATION / 2);
 
     std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
     swipe_actions.emplace_back(std::move(touch_inhibit));

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -122,6 +122,7 @@ MultiFingerDownAction::update_state(const wf::touch::gesture_state_t& state,
 
     if (event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN &&
         state.fingers.size() >= 3) {
+        this->callback();
         return wf::touch::ACTION_STATUS_COMPLETED;
     }
 
@@ -288,11 +289,9 @@ void IGestureManager::addMultiFingerSwipeThenLiftoffGesture(
 //   threshold.
 // * emits a GESTURE_TYPE_SWIPE event once a finger is lifted
 void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
-    auto multi_down = std::make_unique<MultiFingerDownAction>();
-    multi_down->set_duration(GESTURE_BASE_DURATION);
-
-    auto touch_inhibit = std::make_unique<CallbackAction>(
+    auto multi_down = std::make_unique<MultiFingerDownAction>(
         [this]() { this->cancelTouchEventsOnAllWindows(); });
+    multi_down->set_duration(GESTURE_BASE_DURATION);
 
     auto swipe = std::make_unique<CMultiAction>(SWIPE_INCORRECT_DRAG_TOLERANCE,
                                                 sensitivity);
@@ -317,7 +316,7 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
     // swipe_liftoff->set_duration(GESTURE_BASE_DURATION / 2);
 
     std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
-    swipe_actions.emplace_back(std::move(touch_inhibit));
+    swipe_actions.emplace_back(std::move(multi_down));
     swipe_actions.emplace_back(std::move(swipe));
     swipe_actions.emplace_back(std::move(swipe_begin));
     swipe_actions.emplace_back(std::move(swipe_liftoff));

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -302,10 +302,14 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity) {
     auto swipe_ptr = swipe.get();
 
     auto swipe_begin_callback = [swipe_ptr, this]() {
+        if (this->dragGestureActive) {
+            return;
+        }
         const auto gesture = CompletedGesture{GESTURE_TYPE_SWIPE_HOLD,
                                               swipe_ptr->target_direction,
                                               swipe_ptr->finger_count};
-        this->handleGesture(gesture);
+
+        this->dragGestureActive = this->handleGesture(gesture);
     };
     auto swipe_begin = std::make_unique<CallbackAction>(swipe_begin_callback);
 

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -98,8 +98,11 @@ class CMultiAction : public wf::touch::gesture_action_t {
 };
 
 // Completes upon receiving enough touch down events within a short duration
-// upon completion, calls the given callback
 class MultiFingerDownAction : public wf::touch::gesture_action_t {
+// upon completion, calls the given callback.
+//
+// Intended to be used to send cancel events to surfaces when enough fingers
+// touch down in quick succession.
   public:
     MultiFingerDownAction(std::function<void()> callback)
         : callback(callback) {}
@@ -121,6 +124,8 @@ class LiftoffAction : public wf::touch::gesture_action_t {
 };
 
 // This action is used to call a function in between other actions
+//
+// NOTE: this action consumes any event, and must consume an event to work.
 class CallbackAction : public wf::touch::gesture_action_t {
   public:
     CallbackAction(std::function<void()> callback) : callback(callback) {}

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -143,8 +143,6 @@ class IGestureManager {
     bool onTouchMove(const wf::touch::gesture_event_t&);
 
     void addTouchGesture(std::unique_ptr<wf::touch::gesture_t> gesture);
-    void addMultiFingerDragGesture(const float* sensitivity);
-    void addMultiFingerSwipeThenLiftoffGesture(const float* sensitivity);
     void addMultiFingerGesture(const float* sensitivity);
     void addEdgeSwipeGesture(const float* sensitivity);
 

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -91,10 +91,18 @@ class CMultiAction : public wf::touch::gesture_action_t {
 };
 
 // Completes upon receiving enough touch down events within a short duration
+// upon completion, calls the given callback
 class MultiFingerDownAction : public wf::touch::gesture_action_t {
+  public:
+    MultiFingerDownAction(std::function<void()> callback)
+        : callback(callback) {}
+
     wf::touch::action_status_t
     update_state(const wf::touch::gesture_state_t& state,
                  const wf::touch::gesture_event_t& event) override;
+
+  private:
+    std::function<void()> callback;
 };
 
 // Completes upon receiving a touch up event and cancels upon receiving a touch

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -142,7 +142,7 @@ class IGestureManager {
 
     // indicates whether events should be blocked from forwarding to client
     // windows/surfaces
-    bool eventForwardingInhibited() {
+    bool eventForwardingInhibited() const {
         return inhibitTouchEvents;
     };
 
@@ -151,12 +151,20 @@ class IGestureManager {
     wf::touch::gesture_state_t m_sGestureState;
 
     gestureDirection find_swipe_edges(wf::touch::point_t point);
-    virtual SMonitorArea getMonitorArea() const             = 0;
-    virtual void handleGesture(const CompletedGesture& gev) = 0;
-    virtual void handleCancelledGesture()                   = 0;
+    bool dragGestureIsActive() const {
+        return dragGestureActive;
+    }
+    virtual SMonitorArea getMonitorArea() const = 0;
+
+    // handles gesture events and returns whether or not the event is used.
+    virtual bool handleGesture(const CompletedGesture& gev) = 0;
+
+    // this function should cleanup after drag gestures
+    virtual void handleCancelledGesture() = 0;
 
   private:
     bool inhibitTouchEvents;
+    bool dragGestureActive;
 
     // this function is called when needed to send "cancel touch" events to
     // client windows/surfaces

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -137,7 +137,14 @@ class IGestureManager {
     void addTouchGesture(std::unique_ptr<wf::touch::gesture_t> gesture);
     void addMultiFingerDragGesture(const float* sensitivity);
     void addMultiFingerSwipeThenLiftoffGesture(const float* sensitivity);
+    void addMultiFingerGesture(const float* sensitivity);
     void addEdgeSwipeGesture(const float* sensitivity);
+
+    // indicates whether events should be blocked from forwarding to client
+    // windows/surfaces
+    bool eventForwardingInhibited() {
+        return inhibitTouchEvents;
+    };
 
   protected:
     std::vector<std::unique_ptr<wf::touch::gesture_t>> m_vGestures;
@@ -149,5 +156,12 @@ class IGestureManager {
     virtual void handleCancelledGesture()                   = 0;
 
   private:
+    bool inhibitTouchEvents;
+
+    // this function is called when needed to send "cancel touch" events to
+    // client windows/surfaces
+    virtual void sendCancelEventsToWindows() = 0;
+
     void updateGestures(const wf::touch::gesture_event_t&);
+    void cancelTouchEventsOnAllWindows();
 };

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -138,8 +138,16 @@ class CallbackAction : public wf::touch::gesture_action_t {
 class IGestureManager {
   public:
     virtual ~IGestureManager() {}
+    // @return whether this touch event should be blocked from forwarding to the
+    // client window/surface
     bool onTouchDown(const wf::touch::gesture_event_t&);
+
+    // @return whether this touch event should be blocked from forwarding to the
+    // client window/surface
     bool onTouchUp(const wf::touch::gesture_event_t&);
+
+    // @return whether this touch event should be blocked from forwarding to the
+    // client window/surface
     bool onTouchMove(const wf::touch::gesture_event_t&);
 
     void addTouchGesture(std::unique_ptr<wf::touch::gesture_t> gesture);

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -80,6 +80,11 @@ class CMultiAction : public wf::touch::gesture_action_t {
     gestureDirection target_direction = 0;
     int finger_count                  = 0;
 
+    // The action is completed if any number of fingers is moved enough.
+    //
+    // This action should be followed by another that completes upon lifting a
+    // finger to achieve a gesture that completes after a multi-finger swipe is
+    // done and lifted.
     wf::touch::action_status_t
     update_state(const wf::touch::gesture_state_t& state,
                  const wf::touch::gesture_event_t& event) override;

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -22,6 +22,8 @@ constexpr static double HOLD_INCORRECT_DRAG_TOLERANCE = 100;
 constexpr static double GESTURE_INITIAL_TOLERANCE = 40;
 constexpr static uint32_t GESTURE_BASE_DURATION   = 400;
 
+constexpr static uint32_t SEND_CANCEL_EVENT_FINGER_COUNT = 3;
+
 enum eTouchGestureType {
     // Invalid Gesture
     GESTURE_TYPE_SWIPE,

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -90,12 +90,32 @@ class CMultiAction : public wf::touch::gesture_action_t {
     };
 };
 
+// Completes upon receiving enough touch down events within a short duration
+class MultiFingerDownAction : public wf::touch::gesture_action_t {
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state,
+                 const wf::touch::gesture_event_t& event) override;
+};
+
 // Completes upon receiving a touch up event and cancels upon receiving a touch
 // down event.
 class LiftoffAction : public wf::touch::gesture_action_t {
     wf::touch::action_status_t
     update_state(const wf::touch::gesture_state_t& state,
                  const wf::touch::gesture_event_t& event) override;
+};
+
+// This action is used to call a function in between other actions
+class CallbackAction : public wf::touch::gesture_action_t {
+  public:
+    CallbackAction(std::function<void()> callback) : callback(callback) {}
+
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state,
+                 const wf::touch::gesture_event_t& event) override;
+
+  private:
+    const std::function<void()> callback;
 };
 
 /*

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -66,7 +66,6 @@ struct SMonitorArea {
 };
 
 // swipe and with multiple fingers and directions
-// TODO make threshold dynamic so we can adjust it at runtime
 class CMultiAction : public wf::touch::gesture_action_t {
   public:
     //   threshold = base_threshold / sensitivity

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -148,6 +148,10 @@ class IGestureManager {
     void addMultiFingerGesture(const float* sensitivity);
     void addEdgeSwipeGesture(const float* sensitivity);
 
+    bool dragGestureIsActive() const {
+        return dragGestureActive;
+    }
+
     // indicates whether events should be blocked from forwarding to client
     // windows/surfaces
     bool eventForwardingInhibited() const {
@@ -159,9 +163,6 @@ class IGestureManager {
     wf::touch::gesture_state_t m_sGestureState;
 
     gestureDirection find_swipe_edges(wf::touch::point_t point);
-    bool dragGestureIsActive() const {
-        return dragGestureActive;
-    }
     virtual SMonitorArea getMonitorArea() const = 0;
 
     // handles gesture events and returns whether or not the event is used.

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -16,3 +16,5 @@ void CMockGestureManager::handleCancelledGesture() {
     std::cout << "gesture cancelled\n";
     this->cancelled = true;
 }
+
+void CMockGestureManager::sendCancelEventsToWindows() {}

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -7,9 +7,10 @@
 
 CMockGestureManager::CMockGestureManager() {}
 
-void CMockGestureManager::handleGesture(const CompletedGesture& gev) {
+bool CMockGestureManager::handleGesture(const CompletedGesture& gev) {
     std::cout << "gesture triggered: " << gev.to_string() << "\n";
     this->triggered = true;
+    return gev.type != GESTURE_TYPE_SWIPE_HOLD;
 }
 
 void CMockGestureManager::handleCancelledGesture() {
@@ -17,4 +18,6 @@ void CMockGestureManager::handleCancelledGesture() {
     this->cancelled = true;
 }
 
-void CMockGestureManager::sendCancelEventsToWindows() {}
+void CMockGestureManager::sendCancelEventsToWindows() {
+    std::cout << "cancel touch on windows\n";
+}

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -9,8 +9,8 @@ CMockGestureManager::CMockGestureManager() {}
 
 bool CMockGestureManager::handleGesture(const CompletedGesture& gev) {
     std::cout << "gesture triggered: " << gev.to_string() << "\n";
-    this->triggered = true;
-    return gev.type != GESTURE_TYPE_SWIPE_HOLD;
+    this->triggered = this->triggered || gev.type != GESTURE_TYPE_SWIPE_HOLD;
+    return true;
 }
 
 void CMockGestureManager::handleCancelledGesture() {

--- a/src/gestures/test/MockGestureManager.hpp
+++ b/src/gestures/test/MockGestureManager.hpp
@@ -13,7 +13,7 @@ class Tester {
     static void testFindSwipeEdges();
 };
 
-class CMockGestureManager : public IGestureManager {
+class CMockGestureManager final : public IGestureManager {
   public:
     CMockGestureManager();
     ~CMockGestureManager() {}

--- a/src/gestures/test/MockGestureManager.hpp
+++ b/src/gestures/test/MockGestureManager.hpp
@@ -44,5 +44,6 @@ class CMockGestureManager : public IGestureManager {
     }
 
   private:
+    void sendCancelEventsToWindows() override;
     friend Tester;
 };

--- a/src/gestures/test/MockGestureManager.hpp
+++ b/src/gestures/test/MockGestureManager.hpp
@@ -34,7 +34,7 @@ class CMockGestureManager : public IGestureManager {
         return {pos->x, pos->y};
     }
 
-    void handleGesture(const CompletedGesture& gev) override;
+    bool handleGesture(const CompletedGesture& gev) override;
     void handleCancelledGesture() override;
 
   protected:

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -38,6 +38,7 @@ void Tester::testFindSwipeEdges() {
 
 enum class ExpectResultType {
     COMPLETED,
+    DRAG_TRIGGERED,
     CANCELLED,
     CHECK_PROGRESS,
 };
@@ -82,13 +83,17 @@ void ProcessEvents(CMockGestureManager& gm, ExpectResult expect,
         case ExpectResultType::COMPLETED:
             CHECK(gm.triggered);
             break;
+        case ExpectResultType::DRAG_TRIGGERED:
+            CHECK(gm.dragGestureIsActive());
+            break;
         case ExpectResultType::CANCELLED:
             CHECK(gm.cancelled);
             break;
         case ExpectResultType::CHECK_PROGRESS:
-            CHECK(
-                gm.getGestureAt(expect.gesture_index)->get()->get_progress() ==
-                expect.progress);
+            const auto got =
+                gm.getGestureAt(expect.gesture_index)->get()->get_progress();
+            // fuck floating point math
+            CHECK(std::abs(got - expect.progress) < 1e-5);
     }
 }
 
@@ -115,11 +120,13 @@ TEST_CASE("Multifinger: block touch events to client surfaces when more than a "
 TEST_CASE("Swipe Drag: Complete upon moving more than the threshold") {
     std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
-    gm.addMultiFingerDragGesture(&SENSITIVITY);
+    gm.addMultiFingerGesture(&SENSITIVITY);
     const std::vector<TouchEvent> events{
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {450, 290}},
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 1, {500, 300}},
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 2, {550, 290}},
+        {wf::touch::EVENT_TYPE_MOTION, 200, 0, {0, 290}},
+        // CallbackAction needs an extra event to trigger
         {wf::touch::EVENT_TYPE_MOTION, 200, 0, {0, 290}},
         /* FIXME idk why this triggers after one finger movement, should be
         after all finers moved? threshold should be 450, I thought the center is
@@ -127,20 +134,21 @@ TEST_CASE("Swipe Drag: Complete upon moving more than the threshold") {
         // {wf::touch::EVENT_TYPE_MOTION, 200, 1, point_t{50, 300}},
         // {wf::touch::EVENT_TYPE_MOTION, 200, 2, point_t{100, 290}},
     };
-    ProcessEvents(gm, {.type = ExpectResultType::COMPLETED}, events);
+    ProcessEvents(gm, {.type = ExpectResultType::DRAG_TRIGGERED}, events);
 }
 
-TEST_CASE("Swipe Drag: Cancel 2 finger swipe due to moving too much before "
-          "adding new finger, but not enough to trigger 2 finger swipe first") {
+TEST_CASE("Swipe Drag: Cancel 3 finger swipe due to moving too much before "
+          "adding new finger, but not enough to trigger 3 finger swipe first") {
     std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
-    gm.addMultiFingerDragGesture(&SENSITIVITY);
+    gm.addMultiFingerGesture(&SENSITIVITY);
     const std::vector<TouchEvent> events{
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {450, 290}},
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 1, {500, 300}},
+        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 2, {401, 290}},
         {wf::touch::EVENT_TYPE_MOTION, 110, 0, {409, 290}},
         {wf::touch::EVENT_TYPE_MOTION, 110, 1, {459, 300}},
-        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 150, 2, {401, 290}},
+        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 120, 3, {600, 280}},
     };
     ProcessEvents(gm, {.type = ExpectResultType::CANCELLED}, events);
 }
@@ -149,7 +157,7 @@ TEST_CASE("Swipe: Complete upon moving more than the threshold then lifting a "
           "finger") {
     std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
-    gm.addMultiFingerSwipeThenLiftoffGesture(&SENSITIVITY);
+    gm.addMultiFingerGesture(&SENSITIVITY);
 
     const std::vector<TouchEvent> events{
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {450, 290}},

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
@@ -96,6 +97,7 @@ using wf::touch::point_t;
 
 TEST_CASE("Multifinger: block touch events to client surfaces when more than a "
           "certain number of fingers touch down.") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addMultiFingerGesture(&SENSITIVITY);
     const std::vector<TouchEvent> events{
@@ -111,6 +113,7 @@ TEST_CASE("Multifinger: block touch events to client surfaces when more than a "
 }
 
 TEST_CASE("Swipe Drag: Complete upon moving more than the threshold") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addMultiFingerDragGesture(&SENSITIVITY);
     const std::vector<TouchEvent> events{
@@ -129,6 +132,7 @@ TEST_CASE("Swipe Drag: Complete upon moving more than the threshold") {
 
 TEST_CASE("Swipe Drag: Cancel 2 finger swipe due to moving too much before "
           "adding new finger, but not enough to trigger 2 finger swipe first") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addMultiFingerDragGesture(&SENSITIVITY);
     const std::vector<TouchEvent> events{
@@ -143,6 +147,7 @@ TEST_CASE("Swipe Drag: Cancel 2 finger swipe due to moving too much before "
 
 TEST_CASE("Swipe: Complete upon moving more than the threshold then lifting a "
           "finger") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addMultiFingerSwipeThenLiftoffGesture(&SENSITIVITY);
 
@@ -164,6 +169,7 @@ TEST_CASE("Edge Swipe: Complete upon: \n"
           "1. touch down on edge of screen\n"
           "2. swiping more than the threshold, within the time limit, then\n"
           "3. lifting the finger, within the time limit.\n") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addEdgeSwipeGesture(&SENSITIVITY);
 
@@ -178,6 +184,7 @@ TEST_CASE("Edge Swipe: Complete upon: \n"
 }
 
 TEST_CASE("Edge Swipe: Timeout during swiping phase") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addEdgeSwipeGesture(&SENSITIVITY);
 
@@ -193,6 +200,7 @@ TEST_CASE("Edge Swipe: Timout during liftoff phase: \n"
           "1. touch down on edge of screen\n"
           "2. swipe more than the threshold, within the time limit, then\n"
           "3. do not lift finger until after timeout.") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addEdgeSwipeGesture(&SENSITIVITY);
 
@@ -212,6 +220,7 @@ TEST_CASE(
     "3. lift the finger, within the time limit.\n"
     "The starting position of the swipe is checked at the end and should "
     "fail.") {
+    std::cout << "  ==== stdout:" << std::endl;
     CMockGestureManager gm;
     gm.addEdgeSwipeGesture(&SENSITIVITY);
 

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -94,6 +94,22 @@ void ProcessEvents(CMockGestureManager& gm, ExpectResult expect,
 using TouchEvent = wf::touch::gesture_event_t;
 using wf::touch::point_t;
 
+TEST_CASE("Multifinger: block touch events to client surfaces when more than a "
+          "certain number of fingers touch down.") {
+    CMockGestureManager gm;
+    gm.addMultiFingerGesture(&SENSITIVITY);
+    const std::vector<TouchEvent> events{
+        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {450, 290}},
+        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 120, 1, {500, 300}},
+        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 140, 2, {550, 290}},
+    };
+    ProcessEvents(
+        gm, {.type = ExpectResultType::CHECK_PROGRESS, .progress = 1.0 / 4.0},
+        events);
+
+    CHECK(gm.eventForwardingInhibited());
+}
+
 TEST_CASE("Swipe Drag: Complete upon moving more than the threshold") {
     CMockGestureManager gm;
     gm.addMultiFingerDragGesture(&SENSITIVITY);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,65 +16,27 @@ typedef void (*origTouchDown)(void*, wlr_touch_down_event*);
 typedef void (*origTouchUp)(void*, wlr_touch_up_event*);
 typedef void (*origTouchMove)(void*, wlr_touch_motion_event*);
 
-// Inhibit all calls to Hyprland's original touch event handlers.
-inline bool g_bInhibitHyprlandTouchHandlers = false;
-inline std::vector<wlr_surface*> g_vTouchedSurfaces;
-
-inline void markSurfaceAsTouched(wlr_surface& surface) {
-    const auto TOUCHED = std::find(g_vTouchedSurfaces.begin(),
-                                   g_vTouchedSurfaces.end(), &surface);
-    if (TOUCHED == g_vTouchedSurfaces.end()) {
-        g_vTouchedSurfaces.push_back(&surface);
-    }
-}
-
-inline void cancelAllFingers() {
-    for (const auto& window : g_vTouchedSurfaces) {
-        if (!window) {
-            continue;
-        }
-
-        wlr_seat_touch_notify_cancel(g_pCompositor->m_sSeat.seat, window);
-    }
-
-    g_vTouchedSurfaces.clear();
-    g_bInhibitHyprlandTouchHandlers = true;
-}
-
 void hkOnTouchDown(void* thisptr, wlr_touch_down_event* e) {
-    if (e->touch_id == 0) {
-        g_bInhibitHyprlandTouchHandlers = false;
-        g_vTouchedSurfaces.clear();
-    }
-
     const auto BLOCK = g_pGestureManager->onTouchDown(e);
 
-    if (g_bInhibitHyprlandTouchHandlers) {
-        return;
-    }
-
     if (BLOCK) {
-        cancelAllFingers();
         return;
     }
 
     (*(origTouchDown)g_pTouchDownHook->m_pOriginal)(thisptr, e);
 
-    if (g_pInputManager->m_sTouchData.touchFocusSurface) {
-        markSurfaceAsTouched(*g_pInputManager->m_sTouchData.touchFocusSurface);
-    }
+    // TODO: add surface to list of touched surface
+
+    // if (g_pInputManager->m_sTouchData.touchFocusSurface) {
+    //     markSurfaceAsTouched(*g_pInputManager->m_sTouchData.touchFocusSurface);
+    // }
 }
 
 void hkOnTouchUp(void* thisptr, wlr_touch_up_event* e) {
     const auto BLOCK = g_pGestureManager->onTouchUp(e);
 
-    if (g_bInhibitHyprlandTouchHandlers) {
-        return;
-    }
-
     if (BLOCK) {
-        cancelAllFingers();
-        // e->finger_id is not handled by liftAllFingers(), do not return
+        return;
     }
 
     (*(origTouchUp)g_pTouchUpHook->m_pOriginal)(thisptr, e);
@@ -83,12 +45,7 @@ void hkOnTouchUp(void* thisptr, wlr_touch_up_event* e) {
 void hkOnTouchMove(void* thisptr, wlr_touch_motion_event* e) {
     const auto BLOCK = g_pGestureManager->onTouchMove(e);
 
-    if (g_bInhibitHyprlandTouchHandlers) {
-        return;
-    }
-
     if (BLOCK) {
-        cancelAllFingers();
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,12 +24,6 @@ void hkOnTouchDown(void* thisptr, wlr_touch_down_event* e) {
     }
 
     (*(origTouchDown)g_pTouchDownHook->m_pOriginal)(thisptr, e);
-
-    // TODO: add surface to list of touched surface
-
-    // if (g_pInputManager->m_sTouchData.touchFocusSurface) {
-    //     markSurfaceAsTouched(*g_pInputManager->m_sTouchData.touchFocusSurface);
-    // }
 }
 
 void hkOnTouchUp(void* thisptr, wlr_touch_up_event* e) {


### PR DESCRIPTION
this PR aims to reduce unwanted side effects when using gestures, by sending cancel events to client surfaces as soon as enough(3) fingers touch the screen, instead of waiting for the gesture direction to be determined