### PR TITLE
workaround no cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hyprland Touch Gestures
 
 > [!WARNING]
-> There may still be some bugs that render your touch device unusable until you unload the plugin/close Hyprland (https://github.com/horriblename/hyprgrass/issues/27), have a keyboard in hand the first time you try this. This plugin is very alpha, expect breakable changes!  
+> There may still be some bugs that render your touch device unusable until you unload the plugin/close Hyprland (https://github.com/horriblename/hyprgrass/issues/27), have a keyboard in hand the first time you try this. This plugin is very alpha, expect breakable changes!
 
 Please open an issue if you find any bugs. Feel free to make a feature request if you have a suggestion.
 
@@ -94,6 +94,12 @@ plugin {
 
     # must be >= 3
     workspace_swipe_fingers = 3
+
+    experimental {
+      # send proper cancel events to windows instead of hacky touch_up events,
+      # NOT recommended as it crashed a few times, once it's stabilized I'll make it the default
+      send_cancel = 0
+    }
   }
 }
 ```
@@ -127,7 +133,7 @@ where (skip to [examples](#examples) if this is confusing):
      - `finger_count` must be >= 3
      - `direction` is one of `l`, `r`, `u`, `d`, or `ld`, `rd`, `lu`, `ru` for diagonal directions.  
        (l, r, u, d stand for left, right, up, down)
-  3. `edge:<from_edge>:<direction>`
+  2. `edge:<from_edge>:<direction>`
      - `<from_edge>` is from which edge to start from (l/r/u/d)
      - `<direction>` is in which direction to swipe (l/r/u/d/lu/ld/ru/rd)
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,4 @@
 {
-  # WARNING this is mainly for testing if it will work in nix
-  # depending on which part of hyprland is used, it may be necessary to add
-  # the dependencies of Hyprland here as well
   description = "Hyprland plugin for touch gestures";
 
   inputs.hyprland.url = "github:hyprwm/Hyprland";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                                                          SConfigValue{.intValue = 3});
     cfgStatus = cfgStatus && HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:sensitivity",
                                                          SConfigValue{.floatValue = 1.0});
+    cfgStatus = cfgStatus && HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:experimental:send_cancel",
+                                                         SConfigValue{.intValue = 0});
 
     if (!cfgStatus) {
         HyprlandAPI::addNotification(PHANDLE, "config values cannot be properly added", CColor(0.8, 0.2, 0.2, 1.0),


### PR DESCRIPTION
sending cancel events sometimes causes crashes, most likely related to xwayland (#53). This PR disables cancel events by default as a temporary workaround

- fix: don't send cancel events by default, as they have caused crashes
- cleanup: remove old warning
- chore: update README on new config options
