### PR TITLE
Update README: hyprland config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,29 +100,27 @@ wayland.windowManager.hyprland = {
 ### Configuration options:
 
 ```
-plugin {
-  touch_gestures {
-    # The default sensitivity is probably too low on tablet screens,
-    # I recommend turning it up to 4.0
-    sensitivity = 1.0
+plugin:touch_gestures {
+  # The default sensitivity is probably too low on tablet screens,
+  # I recommend turning it up to 4.0
+  sensitivity = 1.0
 
-    # must be >= 3
-    workspace_swipe_fingers = 3
+  # must be >= 3
+  workspace_swipe_fingers = 3
 
-    # switching workspaces by swiping from an edge, this is separate from workspace_swipe_fingers
-    # and can be used at the same time
-    # possible values: l, r, u, or d
-    # to disable it set it to anything else
-    workspace_swipe_edge = d
+  # switching workspaces by swiping from an edge, this is separate from workspace_swipe_fingers
+  # and can be used at the same time
+  # possible values: l, r, u, or d
+  # to disable it set it to anything else
+  workspace_swipe_edge = d
 
-    # in milliseconds
-    long_press_delay = 400
+  # in milliseconds
+  long_press_delay = 400
 
-    experimental {
-      # send proper cancel events to windows instead of hacky touch_up events,
-      # NOT recommended as it crashed a few times, once it's stabilized I'll make it the default
-      send_cancel = 0
-    }
+  experimental {
+    # send proper cancel events to windows instead of hacky touch_up events,
+    # NOT recommended as it crashed a few times, once it's stabilized I'll make it the default
+    send_cancel = 0
   }
 }
 ```


### PR DESCRIPTION
The hyprland wiki is not very clear, but I think this is a better syntax. Anyway, using the previous syntax with nix home-manager lead to a silent override ([here](https://github.com/nix-community/home-manager/blob/93e804e7f8a1eb88bde6117cd5046501e66aa4bd/modules/services/window-managers/hyprland.nix#L202)).