### PR TITLE
workaround: add internal bind dispatcher

### DIFF
--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -5,6 +5,8 @@
 #include <hyprland/src/debug/Log.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/includes.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
+#include <list>
 #include <vector>
 #include <wayfire/touch/touch.hpp>
 #include <wayland-server-core.h>
@@ -28,6 +30,9 @@ class GestureManager : public IGestureManager {
 
     void onLongPressTimeout(uint32_t time_msec);
 
+    // workaround
+    void touchBindDispatcher(std::string args);
+
   protected:
     SMonitorArea getMonitorArea() const override;
     bool handleCompletedGesture(const CompletedGesture& gev) override;
@@ -38,12 +43,15 @@ class GestureManager : public IGestureManager {
     CMonitor* m_pLastTouchedMonitor;
     SMonitorArea m_sMonitorArea;
     wl_event_source* long_press_timer;
+    std::list<SKeybind> internalBinds;
 
     // for workspace swipe
     wf::touch::point_t m_vGestureLastCenter;
     void emulateSwipeBegin(uint32_t time);
     void emulateSwipeEnd(uint32_t time, bool cancelled);
     void emulateSwipeUpdate(uint32_t time);
+
+    bool handleGestureBind(std::string bind, bool pressed);
 
     wf::touch::point_t wlrTouchEventPositionAsPixels(double x, double y) const;
     bool handleWorkspaceSwipe(const GestureDirection direction);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,14 @@
 #include "GestureManager.hpp"
 #include "globals.hpp"
 
-#include <algorithm>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/debug/Log.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/version.h>
 #include <hyprlang.hpp>
-#include <vector>
+#include <string>
 
 const CColor s_pluginColor = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f, 1.0f};
 
@@ -55,6 +55,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:experimental:send_cancel",
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
 #pragma GCC diagnostic pop
+
+    HyprlandAPI::addDispatcher(PHANDLE, "touchBind",
+                               [&](std::string args) { g_pGestureManager->touchBindDispatcher(args); });
 
     const auto hlTargetVersion = GIT_COMMIT_HASH;
     const auto hlVersion       = HyprlandAPI::getHyprlandVersion(PHANDLE);


### PR DESCRIPTION
temporary workaround for #77 

I'm still stuck with Wind*ws so I can't test, so I'm not even sure if this would work.

Usage:

replace your touch binds with the touchBind dispatcher:

```
# old
bind = , edge:d:u, exec, doSomething

# new 
# (exec-once or exec? idk)
exec-once = hyprctl dispatch touchBind ', edge:d:u, exec, doSomething'
```

bindm not supported, I don't think it causes issues anyways