### PR TITLE
removed GetWorkplaceByID call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.so
 compile_flags.txt
+compile_commands.json
+.cache/
 .ccls-cache
 .ccls
 .direnv

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -244,8 +244,12 @@ void GestureManager::handleDragGestureEnd(const DragGesture& gev) {
 }
 
 bool GestureManager::handleWorkspaceSwipe(const GestureDirection direction) {
-    const bool VERTANIMS  = g_pInputManager->m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
-        g_pInputManager->m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
+    const bool VERTANIMS = g_pCompositor->m_pLastMonitor->activeWorkspace
+        ->m_vRenderOffset.getConfig()
+        ->pValues->internalStyle == "slidevert" ||
+        g_pCompositor->m_pLastMonitor->activeWorkspace
+        ->m_vRenderOffset.getConfig()
+        ->pValues->internalStyle.starts_with("slidevert");
 
     const auto horizontal           = GESTURE_DIRECTION_LEFT | GESTURE_DIRECTION_RIGHT;
     const auto vertical             = GESTURE_DIRECTION_UP | GESTURE_DIRECTION_DOWN;


### PR DESCRIPTION
Since the return type of `g_pCompositor->m_pLastMonitor->activeWorkspace` got changed, it no longer was able to be used with `GetWorkplaceByID` .

Removal of that surrounding function resolved issue #100 for me.

Using `g_pInputManager` is indeed probably the correct thing, but this is more of a stopgap solution.

Might be horribly wrong, who knows, tell me what you think.
