### PR TITLE
improve compatibility with mouse binds

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -1,13 +1,17 @@
 #include "GestureManager.hpp"
-#include "hyprland/src/managers/LayoutManager.hpp"
 #include "wayfire/touch/touch.hpp"
 #include <algorithm>
 #include <cstdint>
+
+#define private public
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/debug/Log.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
+#include <hyprland/src/managers/LayoutManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
+#undef private
+
 #include <hyprlang.hpp>
 #include <memory>
 #include <optional>
@@ -223,8 +227,7 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
         case DragGestureType::LONG_PRESS: {
             const auto pos = this->m_sGestureState.get_center().current;
             g_pCompositor->warpCursorTo(Vector2D(pos.x, pos.y));
-            // HACK: g_pInputManager->onMouseMoveUnified is private so I'm using just this
-            g_pLayoutManager->getCurrentLayout()->onMouseMove(Vector2D(pos.x, pos.y));
+            g_pInputManager->mouseMoveUnified(ev.time);
             return;
         }
         case DragGestureType::EDGE_SWIPE:

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -2,10 +2,14 @@
 #include "./gestures/Gestures.hpp"
 #include "gestures/Shared.hpp"
 #include "globals.hpp"
+
+#define private public
 #include <hyprland/src/debug/Log.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/includes.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
+#undef private
+
 #include <list>
 #include <vector>
 #include <wayfire/touch/touch.hpp>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/version.h>
+
 #include <hyprlang.hpp>
 #include <string>
 


### PR DESCRIPTION
The original implementation does not do all the bookkeeping done by normal mouse events. Hopefully using the private mouseMoveUnified() will improve this