### PR TITLE
new bind syntax: use touchbind keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ gestures {
 
 ### Custom Commands
 
-You can also bind gesture events to dispatchers, it currently uses the built-in bind keyword like
-keybinds. This will likely change in the future.
+You can also bind gesture events to dispatchers, using touchbind keyword.
+The syntax is like normal keybinds.
 
 #### Syntax
 
 ```
-bind = , <gesture_name>, <dispatcher>, <args>
+touchbind = , <gesture_name>, <dispatcher>, <args>
 ```
 
 where (skip to [examples](#examples) if this is confusing):
@@ -171,30 +171,32 @@ where (skip to [examples](#examples) if this is confusing):
 #### Examples
 
 ```
-# swipe left from right edge
-bind = , edge:r:l, workspace, +1
+plugin:touch_gestures {
+    # swipe left from right edge
+    touchbind = , edge:r:l, workspace, +1
 
-# swipe up from bottom edge
-bind = , edge:d:u, exec, firefox
+    # swipe up from bottom edge
+    touchbind = , edge:d:u, exec, firefox
 
-# swipe down from left edge
-bind = , edge:l:d, exec, pactl set-sink-volume @DEFAULT_SINK@ -4%
+    # swipe down from left edge
+    touchbind = , edge:l:d, exec, pactl set-sink-volume @DEFAULT_SINK@ -4%
 
-# swipe down with 4 fingers
-# NOTE: swipe events only trigger for finger count of >= 3
-bind = , swipe:4:d, killactive
+    # swipe down with 4 fingers
+    # NOTE: swipe events only trigger for finger count of >= 3
+    touchbind = , swipe:4:d, killactive
 
-# swipe diagonally left and down with 3 fingers
-# l (or r) must come before d and u
-bind = , swipe:3:ld, exec, foot
+    # swipe diagonally left and down with 3 fingers
+    # l (or r) must come before d and u
+    touchbind = , swipe:3:ld, exec, foot
 
-# tap with 3 fingers
-# NOTE: tap events only trigger for finger count of >= 3
-bind = , tap:3, exec, foot
+    # tap with 3 fingers
+    # NOTE: tap events only trigger for finger count of >= 3
+    touchbind = , tap:3, exec, foot
 
-# longpress can trigger mouse binds:
-bindm = , longpress:2, movewindow
-bindm = , longpress:3, resizewindow
+    # longpress can trigger mouse binds:
+    touchbindm = , longpress:2, movewindow
+    touchbindm = , longpress:3, resizewindow
+}
 ```
 
 # Acknowledgements

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -18,6 +18,8 @@
 class GestureManager : public IGestureManager {
   public:
     uint32_t long_press_next_trigger_time;
+    std::list<SKeybind> internalBinds;
+
     GestureManager();
     ~GestureManager();
     // @return whether this touch event should be blocked from forwarding to the
@@ -47,7 +49,6 @@ class GestureManager : public IGestureManager {
     CMonitor* m_pLastTouchedMonitor;
     SMonitorArea m_sMonitorArea;
     wl_event_source* long_press_timer;
-    std::list<SKeybind> internalBinds;
 
     // for workspace swipe
     wf::touch::point_t m_vGestureLastCenter;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,8 +90,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
 #pragma GCC diagnostic pop
 
-    HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});
-    HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bindm", onNewBind, Hyprlang::SHandlerOptions{});
+    HyprlandAPI::addConfigKeyword(PHANDLE, "touchbind", onNewBind, Hyprlang::SHandlerOptions{});
+    HyprlandAPI::addConfigKeyword(PHANDLE, "touchbindm", onNewBind, Hyprlang::SHandlerOptions{});
     static auto P0 = HyprlandAPI::registerCallbackDynamic(
         PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) { onPreConfigReload(); });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,10 @@ void hkOnTouchMove(void* _, SCallbackInfo& cbinfo, std::any e) {
     cbinfo.cancelled = g_pGestureManager->onTouchMove(ev);
 }
 
+static void onPreConfigReload() {
+    g_pGestureManager->internalBinds.clear();
+}
+
 Hyprlang::CParseResult onNewBind(const char* K, const char* V) {
     std::string v = V;
     auto vars     = CVarList(v, 4);
@@ -88,6 +92,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bindm", onNewBind, Hyprlang::SHandlerOptions{});
+    static auto P0 = HyprlandAPI::registerCallbackDynamic(
+        PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) { onPreConfigReload(); });
+
 
     HyprlandAPI::addDispatcher(PHANDLE, "touchBind",
                                [&](std::string args) { g_pGestureManager->touchBindDispatcher(args); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,16 +95,19 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     static auto P0 = HyprlandAPI::registerCallbackDynamic(
         PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) { onPreConfigReload(); });
 
-
-    HyprlandAPI::addDispatcher(PHANDLE, "touchBind",
-                               [&](std::string args) { g_pGestureManager->touchBindDispatcher(args); });
+    HyprlandAPI::addDispatcher(PHANDLE, "touchBind", [&](std::string args) {
+        HyprlandAPI::addNotification(
+            PHANDLE, "[hyprgrass] touchBind dispatcher deprecated, use the plugin:touch_gestures:bind keyword instead",
+            CColor(0.8, 0.2, 0.2, 1.0), 5000);
+        g_pGestureManager->touchBindDispatcher(args);
+    });
 
     const auto hlTargetVersion = GIT_COMMIT_HASH;
     const auto hlVersion       = HyprlandAPI::getHyprlandVersion(PHANDLE);
 
     if (hlVersion.hash != hlTargetVersion) {
         HyprlandAPI::addNotification(PHANDLE, "Mismatched Hyprland version! check logs for details",
-                                     CColor(0.8, 0.2, 0.2, 1.0), 5000);
+                                     CColor(0.8, 0.7, 0.26, 1.0), 5000);
         Debug::log(ERR, "[hyprgrass] version mismatch!");
         Debug::log(ERR, "[hyprgrass] | hyprgrass was built against: {}", hlTargetVersion);
         Debug::log(ERR, "[hyprgrass] | actual hyprland version: {}", hlVersion.hash);


### PR DESCRIPTION
closes #114 

- **feat: use plugin-scoped keyword for binds**
- **clear internalBinds preConfigReload**
- **add deprecation warning for touchBind**
- **rename keywords**
- **update README**
