### PR TITLE
refactor: extract common function

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -85,7 +85,7 @@ bool GestureManager::handleCompletedGesture(const CompletedGesture& gev) {
     return this->handleGestureBind(gev.to_string(), false);
 }
 
-bool GestureManager::handleDragGesture(const DragGesture& gev) {
+bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
     static auto const WORKSPACE_SWIPE_FINGERS =
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:workspace_swipe_fingers")
             ->getDataStaticPtr();
@@ -224,7 +224,7 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
     }
 }
 
-void GestureManager::handleDragGestureEnd(const DragGesture& gev) {
+void GestureManager::handleDragGestureEnd(const DragGestureEvent& gev) {
     Debug::log(LOG, "[hyprgrass] Drag gesture ended: {}", gev.to_string());
     switch (gev.type) {
         case DragGestureType::SWIPE:

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -81,7 +81,7 @@ GestureManager::~GestureManager() {
     wl_event_source_remove(this->long_press_timer);
 }
 
-bool GestureManager::handleCompletedGesture(const CompletedGesture& gev) {
+bool GestureManager::handleCompletedGesture(const CompletedGestureEvent& gev) {
     return this->handleGestureBind(gev.to_string(), false);
 }
 

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -59,9 +59,9 @@ class GestureManager : public IGestureManager {
     Vector2D pixelPositionToPercentagePosition(wf::touch::point_t) const;
     bool handleWorkspaceSwipe(const GestureDirection direction);
 
-    bool handleDragGesture(const DragGesture& gev) override;
+    bool handleDragGesture(const DragGestureEvent& gev) override;
     void dragGestureUpdate(const wf::touch::gesture_event_t&) override;
-    void handleDragGestureEnd(const DragGesture& gev) override;
+    void handleDragGestureEnd(const DragGestureEvent& gev) override;
 
     void updateLongPressTimer(uint32_t current_time, uint32_t delay) override;
     void stopLongPressTimer() override;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -41,7 +41,7 @@ class GestureManager : public IGestureManager {
 
   protected:
     SMonitorArea getMonitorArea() const override;
-    bool handleCompletedGesture(const CompletedGesture& gev) override;
+    bool handleCompletedGesture(const CompletedGestureEvent& gev) override;
     void handleCancelledGesture() override;
 
   private:

--- a/src/gestures/CompletedGesture.cpp
+++ b/src/gestures/CompletedGesture.cpp
@@ -1,6 +1,6 @@
 #include "CompletedGesture.hpp"
 
-std::string CompletedGesture::to_string() const {
+std::string CompletedGestureEvent::to_string() const {
     switch (type) {
         case CompletedGestureType::EDGE_SWIPE:
             return "edge:" + stringifyDirection(this->edge_origin) + ":" + stringifyDirection(this->direction);

--- a/src/gestures/CompletedGesture.hpp
+++ b/src/gestures/CompletedGesture.hpp
@@ -11,7 +11,7 @@ enum class CompletedGestureType {
     // PINCH,
 };
 
-struct CompletedGesture {
+struct CompletedGestureEvent {
     CompletedGestureType type;
     GestureDirection direction;
     int finger_count;

--- a/src/gestures/DragGesture.cpp
+++ b/src/gestures/DragGesture.cpp
@@ -1,6 +1,6 @@
 #include "DragGesture.hpp"
 
-std::string DragGesture::to_string() const {
+std::string DragGestureEvent::to_string() const {
     switch (type) {
         case DragGestureType::LONG_PRESS:
             return "longpress:" + std::to_string(finger_count);

--- a/src/gestures/DragGesture.hpp
+++ b/src/gestures/DragGesture.hpp
@@ -7,7 +7,7 @@ enum class DragGestureType {
     EDGE_SWIPE,
 };
 
-struct DragGesture {
+struct DragGestureEvent {
     DragGestureType type;
     GestureDirection direction;
     int finger_count;

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -28,7 +28,7 @@ void IGestureManager::cancelTouchEventsOnAllWindows() {
         this->sendCancelEventsToWindows();
     }
 }
-bool IGestureManager::emitCompletedGesture(const CompletedGesture& gev) {
+bool IGestureManager::emitCompletedGesture(const CompletedGestureEvent& gev) {
     bool handled = this->handleCompletedGesture(gev);
     if (handled) {
         this->stopLongPressTimer();
@@ -147,8 +147,8 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity, const int6
             this->handleDragGestureEnd(gesture);
             this->activeDragGesture = std::nullopt;
         } else {
-            const auto gesture = CompletedGesture{CompletedGestureType::SWIPE, swipe_ptr->target_direction,
-                                                  static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture = CompletedGestureEvent{CompletedGestureType::SWIPE, swipe_ptr->target_direction,
+                                                       static_cast<int>(this->m_sGestureState.fingers.size())};
 
             this->emitCompletedGesture(gesture);
         }
@@ -166,7 +166,7 @@ void IGestureManager::addMultiFingerTap(const float* sensitivity, const int64_t*
 
     auto ack = [this]() {
         const auto gesture =
-            CompletedGesture{CompletedGestureType::TAP, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
+            CompletedGestureEvent{CompletedGestureType::TAP, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
         if (this->emitCompletedGesture(gesture)) {
             this->cancelTouchEventsOnAllWindows();
         }
@@ -208,8 +208,8 @@ void IGestureManager::addLongPress(const float* sensitivity, const int64_t* dela
             this->handleDragGestureEnd(gesture);
             this->activeDragGesture = std::nullopt;
         } else {
-            const auto gesture = CompletedGesture{CompletedGestureType::LONG_PRESS, 0,
-                                                  static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture = CompletedGestureEvent{CompletedGestureType::LONG_PRESS, 0,
+                                                       static_cast<int>(this->m_sGestureState.fingers.size())};
 
             this->emitCompletedGesture(gesture);
         };
@@ -271,7 +271,7 @@ void IGestureManager::addEdgeSwipeGesture(const float* sensitivity, const int64_
         }
         auto direction = edge_ptr->target_direction;
         auto gesture =
-            CompletedGesture{CompletedGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges};
+            CompletedGestureEvent{CompletedGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges};
         this->emitCompletedGesture(gesture);
     };
     auto cancel = [this]() { this->handleCancelledGesture(); };

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -37,7 +37,7 @@ bool IGestureManager::emitCompletedGesture(const CompletedGesture& gev) {
     return handled;
 }
 
-bool IGestureManager::emitDragGesture(const DragGesture& gev) {
+bool IGestureManager::emitDragGesture(const DragGestureEvent& gev) {
     bool handled = this->handleDragGesture(gev);
     if (handled) {
         this->stopLongPressTimer();
@@ -125,8 +125,8 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity, const int6
         if (this->activeDragGesture.has_value()) {
             return;
         }
-        const auto gesture = DragGesture{DragGestureType::SWIPE, swipe_ptr->target_direction,
-                                         static_cast<int>(this->m_sGestureState.fingers.size())};
+        const auto gesture = DragGestureEvent{DragGestureType::SWIPE, swipe_ptr->target_direction,
+                                              static_cast<int>(this->m_sGestureState.fingers.size())};
 
         this->activeDragGesture = this->emitDragGesture(gesture) ? std::optional(gesture) : std::nullopt;
     });
@@ -142,7 +142,7 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity, const int6
     auto ack = [swipe_ptr, this]() {
         if (this->activeDragGesture.has_value() && this->activeDragGesture->type == DragGestureType::SWIPE) {
             const auto gesture =
-                DragGesture{DragGestureType::SWIPE, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
+                DragGestureEvent{DragGestureType::SWIPE, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
 
             this->handleDragGestureEnd(gesture);
             this->activeDragGesture = std::nullopt;
@@ -185,8 +185,8 @@ void IGestureManager::addLongPress(const float* sensitivity, const int64_t* dela
             if (this->activeDragGesture.has_value()) {
                 return;
             }
-            const auto gesture =
-                DragGesture{DragGestureType::LONG_PRESS, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture = DragGestureEvent{DragGestureType::LONG_PRESS, 0,
+                                                  static_cast<int>(this->m_sGestureState.fingers.size())};
 
             if (this->emitDragGesture(gesture)) {
                 this->activeDragGesture = std::optional(gesture);
@@ -202,8 +202,8 @@ void IGestureManager::addLongPress(const float* sensitivity, const int64_t* dela
 
     auto ack = [this]() {
         if (this->activeDragGesture.has_value() && this->activeDragGesture->type == DragGestureType::LONG_PRESS) {
-            const auto gesture =
-                DragGesture{DragGestureType::LONG_PRESS, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture = DragGestureEvent{DragGestureType::LONG_PRESS, 0,
+                                                  static_cast<int>(this->m_sGestureState.fingers.size())};
 
             this->handleDragGestureEnd(gesture);
             this->activeDragGesture = std::nullopt;
@@ -232,7 +232,7 @@ void IGestureManager::addEdgeSwipeGesture(const float* sensitivity, const int64_
             return;
         }
         auto direction = edge_ptr->target_direction;
-        auto gesture   = DragGesture{DragGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges};
+        auto gesture   = DragGestureEvent{DragGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges};
         if (this->emitDragGesture(gesture)) {
             this->activeDragGesture = std::optional(gesture);
             this->cancelTouchEventsOnAllWindows();
@@ -256,10 +256,10 @@ void IGestureManager::addEdgeSwipeGesture(const float* sensitivity, const int64_
         auto origin_edges = find_swipe_edges(m_sGestureState.get_center().origin);
 
         if (this->activeDragGesture.has_value() && this->activeDragGesture->type == DragGestureType::EDGE_SWIPE) {
-            const auto gesture = DragGesture{.type         = DragGestureType::EDGE_SWIPE,
-                                             .direction    = edge_ptr->target_direction,
-                                             .finger_count = edge_ptr->finger_count,
-                                             .edge_origin  = origin_edges};
+            const auto gesture = DragGestureEvent{.type         = DragGestureType::EDGE_SWIPE,
+                                                  .direction    = edge_ptr->target_direction,
+                                                  .finger_count = edge_ptr->finger_count,
+                                                  .edge_origin  = origin_edges};
 
             this->handleDragGestureEnd(gesture);
             this->activeDragGesture = std::nullopt;

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -42,7 +42,7 @@ class IGestureManager {
     void addLongPress(const float* sensitivity, const int64_t* delay);
     void addEdgeSwipeGesture(const float* sensitivity, const int64_t* timeout);
 
-    std::optional<DragGesture> getActiveDragGesture() const {
+    std::optional<DragGestureEvent> getActiveDragGesture() const {
         return activeDragGesture;
     }
 
@@ -63,13 +63,13 @@ class IGestureManager {
     virtual bool handleCompletedGesture(const CompletedGesture& gev) = 0;
 
     // called at the start of drag evetns and returns whether or not the event is used.
-    virtual bool handleDragGesture(const DragGesture& gev) = 0;
+    virtual bool handleDragGesture(const DragGestureEvent& gev) = 0;
 
     // called on every touch event while a drag gesture is active
     virtual void dragGestureUpdate(const wf::touch::gesture_event_t&) = 0;
 
     // called at the end of a drag event
-    virtual void handleDragGestureEnd(const DragGesture& gev) = 0;
+    virtual void handleDragGestureEnd(const DragGestureEvent& gev) = 0;
 
     // this function should cleanup after drag gestures
     virtual void handleCancelledGesture() = 0;
@@ -79,14 +79,14 @@ class IGestureManager {
 
   private:
     bool inhibitTouchEvents;
-    std::optional<DragGesture> activeDragGesture;
+    std::optional<DragGestureEvent> activeDragGesture;
 
     // this function is called when needed to send "cancel touch" events to
     // client windows/surfaces
     virtual void sendCancelEventsToWindows() = 0;
 
     bool emitCompletedGesture(const CompletedGesture& gev);
-    bool emitDragGesture(const DragGesture& gev);
+    bool emitDragGesture(const DragGestureEvent& gev);
 
     void updateGestures(const wf::touch::gesture_event_t&);
     void cancelTouchEventsOnAllWindows();

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -87,6 +87,7 @@ class IGestureManager {
 
     bool emitCompletedGesture(const CompletedGestureEvent& gev);
     bool emitDragGesture(const DragGestureEvent& gev);
+    bool emitDragGestureEnd(const DragGestureEvent& gev);
 
     void updateGestures(const wf::touch::gesture_event_t&);
     void cancelTouchEventsOnAllWindows();

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -60,7 +60,7 @@ class IGestureManager {
     virtual SMonitorArea getMonitorArea() const = 0;
 
     // handles gesture events and returns whether or not the event is used.
-    virtual bool handleCompletedGesture(const CompletedGesture& gev) = 0;
+    virtual bool handleCompletedGesture(const CompletedGestureEvent& gev) = 0;
 
     // called at the start of drag evetns and returns whether or not the event is used.
     virtual bool handleDragGesture(const DragGestureEvent& gev) = 0;
@@ -85,7 +85,7 @@ class IGestureManager {
     // client windows/surfaces
     virtual void sendCancelEventsToWindows() = 0;
 
-    bool emitCompletedGesture(const CompletedGesture& gev);
+    bool emitCompletedGesture(const CompletedGestureEvent& gev);
     bool emitDragGesture(const DragGestureEvent& gev);
 
     void updateGestures(const wf::touch::gesture_event_t&);

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -5,7 +5,7 @@
 
 #define CONFIG_SENSITIVITY 1.0
 
-bool CMockGestureManager::handleCompletedGesture(const CompletedGesture& gev) {
+bool CMockGestureManager::handleCompletedGesture(const CompletedGestureEvent& gev) {
     std::cout << "gesture triggered: " << gev.to_string() << "\n";
     this->triggered = true;
     return true;

--- a/src/gestures/test/MockGestureManager.cpp
+++ b/src/gestures/test/MockGestureManager.cpp
@@ -11,7 +11,7 @@ bool CMockGestureManager::handleCompletedGesture(const CompletedGesture& gev) {
     return true;
 }
 
-bool CMockGestureManager::handleDragGesture(const DragGesture& gev) {
+bool CMockGestureManager::handleDragGesture(const DragGestureEvent& gev) {
     std::cout << "drag started: " << gev.to_string() << "\n";
     return this->handlesDragEvents;
 }
@@ -20,7 +20,7 @@ void CMockGestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ge
     std::cout << "drag update" << std::endl;
 }
 
-void CMockGestureManager::handleDragGestureEnd(const DragGesture& gev) {
+void CMockGestureManager::handleDragGestureEnd(const DragGestureEvent& gev) {
     std::cout << "drag end: " << gev.to_string() << "\n";
     this->dragEnded = true;
 }

--- a/src/gestures/test/MockGestureManager.hpp
+++ b/src/gestures/test/MockGestureManager.hpp
@@ -51,9 +51,9 @@ class CMockGestureManager final : public IGestureManager {
     }
 
     bool handleCompletedGesture(const CompletedGesture& gev) override;
-    bool handleDragGesture(const DragGesture& gev) override;
+    bool handleDragGesture(const DragGestureEvent& gev) override;
     void dragGestureUpdate(const wf::touch::gesture_event_t&) override;
-    void handleDragGestureEnd(const DragGesture& gev) override;
+    void handleDragGestureEnd(const DragGestureEvent& gev) override;
     void handleCancelledGesture() override;
 
     void updateLongPressTimer(uint32_t current_time, uint32_t delay) override {}

--- a/src/gestures/test/MockGestureManager.hpp
+++ b/src/gestures/test/MockGestureManager.hpp
@@ -50,7 +50,7 @@ class CMockGestureManager final : public IGestureManager {
         return {pos->x, pos->y};
     }
 
-    bool handleCompletedGesture(const CompletedGesture& gev) override;
+    bool handleCompletedGesture(const CompletedGestureEvent& gev) override;
     bool handleDragGesture(const DragGestureEvent& gev) override;
     void dragGestureUpdate(const wf::touch::gesture_event_t&) override;
     void handleDragGestureEnd(const DragGestureEvent& gev) override;

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -52,7 +52,7 @@ struct ExpectResult {
     float progress = 0.0;
 
     // which of the m_vGestures to use
-    // usually the first (0)
+    // usually the first (0) in tests
     int gesture_index = 0;
 };
 
@@ -334,5 +334,19 @@ TEST_CASE("Edge Swipe Drag: begin") {
         {wf::touch::EVENT_TYPE_MOTION, 200, 0, {455, 300}},
     };
     const ExpectResult expected_result = {ExpectResultType::DRAG_TRIGGERED, 1.0};
+    ProcessEvents(gm, expected_result, events);
+}
+
+TEST_CASE("Edge Swipe Drag: emits drag end event") {
+    auto gm = CMockGestureManager::newDragHandler();
+    gm.addEdgeSwipeGesture(&SENSITIVITY, &LONG_PRESS_DELAY);
+
+    const std::vector<TouchEvent> events{
+        {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {5, 300}}, {wf::touch::EVENT_TYPE_MOTION, 150, 0, {250, 300}},
+        {wf::touch::EVENT_TYPE_MOTION, 200, 0, {455, 300}},   {wf::touch::EVENT_TYPE_MOTION, 250, 0, {600, 300}},
+        {wf::touch::EVENT_TYPE_TOUCH_UP, 300, 0, {700, 400}},
+    };
+
+    const ExpectResult expected_result = {ExpectResultType::DRAG_ENDED, 1.0};
     ProcessEvents(gm, expected_result, events);
 }


### PR DESCRIPTION
- **rework workspace swipe to use internal functions**
- **remove unused**
- **fix: inverted workspace swipe**
- **remove sus code**
- **fix: forgot to report handled drag gesture**
- **fix: typo**
- **one to one workspace swipes**
- **forgot to handleDragGestureEnd in edge swipe**
- **rename: DragGesture -> DragGestureEvent**
- **rename: CompletedGesture -> CompletedGestureEvent**
- **refactor: extract common function**
- **tests: add test case for edge drag end**
