### PR TITLE
Fix build on openSUSE.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,9 @@ shared_module('hyprgrass',
   dependencies: [
     wftouch,
     dependency('pixman-1'),
+    dependency('libinput'),
+    dependency('wayland-server'),
+    dependency('xkbcommon'),
     dependency('libdrm'),
     hyprland_headers
   ],


### PR DESCRIPTION
Same as https://github.com/hyprwm/hyprland-plugins/pull/64 but for this plugin.