### PR TITLE
Emulate touchpad swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ plugin {
   # in pixels, the distance from the edge that is considered an edge
   edge_margin = 10
 
+  # emulates touchpad swipes when swiping in a direction that does not trigger workspace swipe.
+  # ONLY triggers when finger count is equal to workspace_swipe_fingers
+  #
+  # might be removed in the future in favor of event hooks
+  emulate_touchpad_swipe = false
+
   experimental {
     # send proper cancel events to windows instead of hacky touch_up events,
     # NOT recommended as it crashed a few times, once it's stabilized I'll make it the default

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -111,6 +111,9 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
     static auto const RESIZE_LONG_PRESS =
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:resize_on_border_long_press")
             ->getDataStaticPtr();
+    static auto const EMULATE_TOUCHPAD =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe")
+            ->getDataStaticPtr();
 
     static auto PBORDERSIZE =
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "general:border_size")->getDataStaticPtr();
@@ -132,6 +135,10 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
             if (this->handleWorkspaceSwipe(gev.direction))
                 return true;
 
+            if (!**EMULATE_TOUCHPAD)
+                return false;
+
+            this->workspaceSwipeActive       = false; // reset just in case
             this->emulatedSwipePoint         = this->m_sGestureState.get_center().current;
             IPointer::SSwipeBeginEvent swipe = {.fingers = static_cast<uint32_t>(m_sGestureState.fingers.size())};
             g_pInputManager->onSwipeBegin(swipe);
@@ -246,6 +253,9 @@ bool GestureManager::handleGestureBind(std::string bind, bool pressed) {
 void GestureManager::handleCancelledGesture() {}
 
 void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
+    static auto const EMULATE_TOUCHPAD =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe")
+            ->getDataStaticPtr();
 
     if (!this->getActiveDragGesture().has_value()) {
         return;
@@ -255,7 +265,7 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
         case DragGestureType::SWIPE:
             if (this->workspaceSwipeActive) {
                 this->updateWorkspaceSwipe();
-            } else {
+            } else if (**EMULATE_TOUCHPAD) {
                 const auto currentPoint           = this->m_sGestureState.get_center().current;
                 const auto delta                  = currentPoint - this->emulatedSwipePoint;
                 IPointer::SSwipeUpdateEvent swipe = {
@@ -277,14 +287,17 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
 }
 
 void GestureManager::handleDragGestureEnd(const DragGestureEvent& gev) {
-    Debug::log(LOG, "[hyprgrass] Drag gesture ended: {}", gev.to_string());
+    static auto const EMULATE_TOUCHPAD =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe")
+            ->getDataStaticPtr();
 
+    Debug::log(LOG, "[hyprgrass] Drag gesture ended: {}", gev.to_string());
     switch (gev.type) {
         case DragGestureType::SWIPE:
             if (this->workspaceSwipeActive) {
                 g_pInputManager->endWorkspaceSwipe();
                 this->workspaceSwipeActive = false;
-            } else {
+            } else if (**EMULATE_TOUCHPAD) {
                 g_pInputManager->onSwipeEnd(IPointer::SSwipeEndEvent{.cancelled = false});
             }
             return;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -55,6 +55,7 @@ class GestureManager : public IGestureManager {
         bool active = false;
         CCssGapData old_gaps_in;
     } resizeOnBorderInfo;
+    bool workspaceSwipeActive = false;
 
     bool handleGestureBind(std::string bind, bool pressed);
 

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -56,6 +56,7 @@ class GestureManager : public IGestureManager {
         CCssGapData old_gaps_in;
     } resizeOnBorderInfo;
     bool workspaceSwipeActive = false;
+    wf::touch::point_t emulatedSwipePoint;
 
     bool handleGestureBind(std::string bind, bool pressed);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                                 Hyprlang::CConfigValue((Hyprlang::INT)1));
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:resize_on_border_long_press",
                                 Hyprlang::CConfigValue((Hyprlang::INT)1));
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe",
+                                Hyprlang::CConfigValue((Hyprlang::INT)0));
 #pragma GCC diagnostic pop
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});


### PR DESCRIPTION
emulates touchpad swipe when swiping in a not-workspace-swipe direction. only triggered when finger count is workspace_swipe_fingers. this is to avoid interpreting every swipe as a touchpad swipe (which might not be desired)