### PR TITLE
Add circles on touch for debugging

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,9 @@
     inherit (hyprland.inputs) nixpkgs;
     withPkgsFor = fn: nixpkgs.lib.genAttrs (builtins.attrNames hyprland.packages) (system: fn system nixpkgs.legacyPackages.${system});
   in {
+    # for debugging
+    inherit inputs;
+
     packages = withPkgsFor (system: pkgs: let
       hyprgrassPackage = pkgs.callPackage ./nix/default.nix {
         inherit (hyprland.packages.${system}) hyprland;

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -1,0 +1,70 @@
+#include "TouchVisualizer.hpp"
+#include "src/devices/ITouch.hpp"
+#include "src/macros.hpp"
+#include "src/render/Renderer.hpp"
+#include <hyprland/src/SharedDefs.hpp>
+
+void Visualizer::onRender() {
+    if (this->finger_positions.size() < 1) {
+        return;
+    }
+
+    // this->finger_positions
+}
+
+void Visualizer::onTouchDown(ITouch::SDownEvent ev) {
+    this->finger_positions.push_back(std::pair(ev.touchID, ev.pos));
+    this->prev_finger_positions.push_back(std::pair(ev.touchID, ev.pos));
+}
+
+void Visualizer::onTouchUp(ITouch::SUpEvent ev) {
+    for (auto iter = this->prev_finger_positions.begin(); iter != this->prev_finger_positions.end(); iter++) {
+        this->prev_finger_positions.erase(iter);
+    }
+
+    for (auto iter = this->finger_positions.begin(); iter != this->finger_positions.end(); iter++) {
+        this->finger_positions.erase(iter);
+    }
+}
+
+void Visualizer::onTouchMotion(ITouch::SMotionEvent ev) {
+    for (auto& pair : this->finger_positions) {
+        if (pair.first != ev.touchID)
+            continue;
+
+        for (auto& prev : this->prev_finger_positions) {
+            if (prev.first != ev.touchID)
+                continue;
+
+            prev.second = pair.second;
+            pair.second = ev.pos;
+
+            return;
+        }
+        break;
+    }
+}
+
+void Visualizer::damageAll() {
+    CBox dm;
+    for (const auto& point : this->prev_finger_positions) {
+        dm = CBox{point.second.x - TOUCH_POINT_RADIUS, point.second.y - TOUCH_POINT_RADIUS,
+                  static_cast<double>(2 * TOUCH_POINT_RADIUS), static_cast<double>(2 * TOUCH_POINT_RADIUS)};
+        g_pHyprRenderer->damageBox(&dm);
+    }
+}
+
+void Visualizer::damageFinger(uint64_t id) {
+    for (const auto& point : this->prev_finger_positions) {
+        if (point.first != id) {
+            continue;
+        }
+
+        CBox dm = {point.second.x - TOUCH_POINT_RADIUS, point.second.y - TOUCH_POINT_RADIUS,
+                   static_cast<double>(2 * TOUCH_POINT_RADIUS), static_cast<double>(2 * TOUCH_POINT_RADIUS)};
+        g_pHyprRenderer->damageBox(&dm);
+        return;
+    }
+
+    RASSERT(false, "Visualizer tried to damage non-existent finger id {}", id)
+}

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -65,8 +65,6 @@ void Visualizer::onRender() {
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, monSize.x, monSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 
-    Debug::log(LOG, "drawing at {}, {}, {}, {}", dmg.x, dmg.y, dmg.w, dmg.h);
-
     g_pHyprOpenGL->renderTexture(this->texture, &dmg, 1.f, 0, true);
 }
 

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -84,15 +84,6 @@ void Visualizer::onTouchMotion(ITouch::SMotionEvent ev) {
     this->damageFinger(ev.touchID);
 }
 
-void Visualizer::damageAll() {
-    CBox dm;
-    for (const auto& point : this->prev_finger_positions) {
-        dm = CBox{point.second.x - TOUCH_POINT_RADIUS, point.second.y - TOUCH_POINT_RADIUS,
-                  static_cast<double>(2 * TOUCH_POINT_RADIUS), static_cast<double>(2 * TOUCH_POINT_RADIUS)};
-        g_pHyprRenderer->damageBox(&dm);
-    }
-}
-
 void Visualizer::damageFinger(int32_t id) {
     for (const auto& point : this->prev_finger_positions) {
         if (point.first != id) {

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -13,8 +13,6 @@ CBox boxAroundCenter(Vector2D center, double radius) {
 }
 
 Visualizer::Visualizer() {
-    this->texture.allocate();
-
     this->cairoSurface =
         cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 2 * TOUCH_POINT_RADIUS, 2 * TOUCH_POINT_RADIUS);
     auto cairo = cairo_create(this->cairoSurface);
@@ -39,21 +37,23 @@ void Visualizer::onRender() {
         return;
     }
 
-    const auto pos      = this->finger_positions[0].second;
-    const auto last_pos = this->prev_finger_positions[0].second;
+    // FIXME: I am almost 100% certain this is wrong
+    const auto monitor = g_pCompositor->m_pLastMonitor.get();
+    const auto monSize = monitor->vecSize;
+
+    const auto pos      = this->finger_positions[0] * monSize;
+    const auto last_pos = this->prev_finger_positions[0] * monSize;
     auto dmg            = boxAroundCenter(pos, TOUCH_POINT_RADIUS);
     auto last_dmg       = boxAroundCenter(last_pos, TOUCH_POINT_RADIUS);
 
     CRegion damage = {pos.x - TOUCH_POINT_RADIUS, pos.y - TOUCH_POINT_RADIUS,
                       static_cast<double>(2 * TOUCH_POINT_RADIUS), static_cast<double>(2 * TOUCH_POINT_RADIUS)};
 
-    // FIXME: I am almost 100% certain this is wrong
-    const auto monitor = g_pCompositor->m_pLastMonitor.get();
-    const auto monSize = monitor->vecSize;
-
-    // idk what this does
     g_pHyprRenderer->damageBox(&dmg);
     g_pHyprRenderer->damageBox(&last_dmg);
+
+    // idk what this does
+    g_pCompositor->scheduleFrameForMonitor(monitor);
 
     const auto data = cairo_image_surface_get_data(this->cairoSurface);
 
@@ -64,42 +64,25 @@ void Visualizer::onRender() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, monSize.x, monSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-    g_pHyprOpenGL->renderTexture(this->texture, &dmg, 1.f);
 
-    g_pCompositor->scheduleFrameForMonitor(monitor);
+    Debug::log(LOG, "drawing at {}, {}, {}, {}", dmg.x, dmg.y, dmg.w, dmg.h);
+
+    g_pHyprOpenGL->renderTexture(this->texture, &dmg, 1.f, 0, true);
 }
 
 void Visualizer::onTouchDown(ITouch::SDownEvent ev) {
-    this->finger_positions.push_back(std::pair(ev.touchID, ev.pos));
-    this->prev_finger_positions.push_back(std::pair(ev.touchID, ev.pos));
+    this->finger_positions.emplace(ev.touchID, ev.pos);
+    this->prev_finger_positions.emplace(std::pair(ev.touchID, ev.pos));
 }
 
 void Visualizer::onTouchUp(ITouch::SUpEvent ev) {
-    for (auto iter = this->prev_finger_positions.begin(); iter != this->prev_finger_positions.end(); iter++) {
-        this->prev_finger_positions.erase(iter);
-    }
-
-    for (auto iter = this->finger_positions.begin(); iter != this->finger_positions.end(); iter++) {
-        this->finger_positions.erase(iter);
-    }
+    this->finger_positions.erase(ev.touchID);
+    this->prev_finger_positions.erase(ev.touchID);
 }
 
 void Visualizer::onTouchMotion(ITouch::SMotionEvent ev) {
-    for (auto& pair : this->finger_positions) {
-        if (pair.first != ev.touchID)
-            continue;
-
-        for (auto& prev : this->prev_finger_positions) {
-            if (prev.first != ev.touchID)
-                continue;
-
-            prev.second = pair.second;
-            pair.second = ev.pos;
-
-            return;
-        }
-        break;
-    }
+    this->prev_finger_positions[ev.touchID] = this->finger_positions[ev.touchID];
+    this->finger_positions[ev.touchID]      = ev.pos;
 }
 
 void Visualizer::damageAll() {

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -41,20 +41,7 @@ Visualizer::~Visualizer() {
         cairo_surface_destroy(this->cairoSurface);
 }
 
-void Visualizer::onPreRender() {
-    for (auto& finger : this->finger_positions) {
-        const auto pos = finger.second.curr;
-
-        if (finger.second.last_rendered.has_value()) {
-            CBox dmg = boxAroundCenter(finger.second.last_rendered.value(), TOUCH_POINT_RADIUS);
-            g_pHyprRenderer->damageBox(&dmg);
-        }
-        finger.second.last_rendered = std::optional(finger.second.curr);
-        CBox dmg                    = boxAroundCenter(pos, TOUCH_POINT_RADIUS);
-
-        g_pHyprRenderer->damageBox(&dmg);
-    }
-}
+void Visualizer::onPreRender() {}
 
 void Visualizer::onRender() {
     if (this->finger_positions.size() < 1) {
@@ -65,6 +52,11 @@ void Visualizer::onRender() {
     const auto monSize = monitor->vecPixelSize;
 
     for (auto& finger : this->finger_positions) {
+        if (finger.second.last_rendered.has_value()) {
+            CBox dmg = boxAroundCenter(finger.second.last_rendered.value(), TOUCH_POINT_RADIUS);
+            g_pHyprRenderer->damageBox(&dmg);
+        }
+
         CBox dmg = boxAroundCenter(finger.second.curr, TOUCH_POINT_RADIUS);
         g_pHyprRenderer->damageBox(&dmg);
 

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -69,15 +69,19 @@ void Visualizer::onRender() {
 void Visualizer::onTouchDown(ITouch::SDownEvent ev) {
     this->finger_positions.emplace(ev.touchID, ev.pos);
     this->prev_finger_positions.emplace(std::pair(ev.touchID, ev.pos));
+    this->damageFinger(ev.touchID);
 }
 
 void Visualizer::onTouchUp(ITouch::SUpEvent ev) {
+    this->damageFinger(ev.touchID);
     this->finger_positions.erase(ev.touchID);
     this->prev_finger_positions.erase(ev.touchID);
 }
 
 void Visualizer::onTouchMotion(ITouch::SMotionEvent ev) {
+    this->damageFinger(ev.touchID);
     this->finger_positions[ev.touchID] = ev.pos;
+    this->damageFinger(ev.touchID);
 }
 
 void Visualizer::damageAll() {

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -19,7 +19,7 @@ Visualizer::Visualizer() {
     auto cairo = cairo_create(cairoSurface);
 
     cairo_arc(cairo, R, R, R, 0, 2 * PI);
-    cairo_set_source_rgba(cairo, 0.8, 0.8, 0.1, 0.8);
+    cairo_set_source_rgba(cairo, 0.8, 0.8, 0.1, 0.6);
     cairo_fill(cairo);
 
     cairo_destroy(cairo);

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -37,7 +37,7 @@ void Visualizer::onRender() {
 
     // FIXME: I am almost 100% certain this is wrong
     const auto monitor = g_pCompositor->m_pLastMonitor.get();
-    const auto monSize = monitor->vecSize;
+    const auto monSize = monitor->vecPixelSize;
 
     const auto pos      = this->finger_positions[0] * monSize;
     const auto last_pos = this->prev_finger_positions[0] * monSize;

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -1,15 +1,72 @@
 #include "TouchVisualizer.hpp"
 #include "src/devices/ITouch.hpp"
+#include "src/helpers/Region.hpp"
 #include "src/macros.hpp"
+#include "src/render/OpenGL.hpp"
 #include "src/render/Renderer.hpp"
+#include <cairo/cairo.h>
+#include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/SharedDefs.hpp>
+
+CBox boxAroundCenter(Vector2D center, double radius) {
+    return CBox(center.x, center.y, radius, radius);
+}
+
+Visualizer::Visualizer() {
+    this->texture.allocate();
+
+    this->cairoSurface =
+        cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 2 * TOUCH_POINT_RADIUS, 2 * TOUCH_POINT_RADIUS);
+    auto cairo = cairo_create(this->cairoSurface);
+
+    const double R = TOUCH_POINT_RADIUS;
+    auto radpat    = cairo_pattern_create_radial(R, R, R, R, R, R);
+    cairo_pattern_add_color_stop_rgba(radpat, 0, 1.0, 1.0, 1.0, 0.8);
+    cairo_set_source(cairo, radpat);
+    cairo_fill(cairo);
+
+    cairo_pattern_destroy(radpat);
+    cairo_destroy(cairo);
+}
+
+Visualizer::~Visualizer() {
+    if (this->cairoSurface)
+        cairo_surface_destroy(this->cairoSurface);
+}
 
 void Visualizer::onRender() {
     if (this->finger_positions.size() < 1) {
         return;
     }
 
-    // this->finger_positions
+    const auto pos      = this->finger_positions[0].second;
+    const auto last_pos = this->prev_finger_positions[0].second;
+    auto dmg            = boxAroundCenter(pos, TOUCH_POINT_RADIUS);
+    auto last_dmg       = boxAroundCenter(last_pos, TOUCH_POINT_RADIUS);
+
+    CRegion damage = {pos.x - TOUCH_POINT_RADIUS, pos.y - TOUCH_POINT_RADIUS,
+                      static_cast<double>(2 * TOUCH_POINT_RADIUS), static_cast<double>(2 * TOUCH_POINT_RADIUS)};
+
+    // FIXME: I am almost 100% certain this is wrong
+    const auto monitor = g_pCompositor->m_pLastMonitor.get();
+    const auto monSize = monitor->vecSize;
+
+    // idk what this does
+    g_pHyprRenderer->damageBox(&dmg);
+    g_pHyprRenderer->damageBox(&last_dmg);
+
+    const auto data = cairo_image_surface_get_data(this->cairoSurface);
+
+    // no deallocate???
+    this->texture.allocate();
+    glBindTexture(GL_TEXTURE_2D, this->texture.m_iTexID);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, monSize.x, monSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+    g_pHyprOpenGL->renderTexture(this->texture, &dmg, 1.f);
+
+    g_pCompositor->scheduleFrameForMonitor(monitor);
 }
 
 void Visualizer::onTouchDown(ITouch::SDownEvent ev) {
@@ -54,7 +111,7 @@ void Visualizer::damageAll() {
     }
 }
 
-void Visualizer::damageFinger(uint64_t id) {
+void Visualizer::damageFinger(int32_t id) {
     for (const auto& point : this->prev_finger_positions) {
         if (point.first != id) {
             continue;

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -48,18 +48,18 @@ void Visualizer::onRender() {
         return;
     }
 
-    const auto monitor = g_pCompositor->m_pLastMonitor.get();
-    const auto monSize = monitor->vecPixelSize;
+    const auto monitor = g_pCompositor->m_pLastMonitor.lock();
+
+    // HACK: should not damage monitor, however, I don't understand jackshit
+    // about damage so here we are.
+    // If you know how to do damage properly I BEG OF YOU PLEASE ABSOLVE ME
+    // OF MY SINS
+    if (this->finger_positions.size()) {
+        g_pHyprRenderer->damageMonitor(monitor);
+    }
 
     for (auto& finger : this->finger_positions) {
-        if (finger.second.last_rendered.has_value()) {
-            CBox dmg = boxAroundCenter(finger.second.last_rendered.value(), TOUCH_POINT_RADIUS);
-            g_pHyprRenderer->damageBox(&dmg);
-        }
-
         CBox dmg = boxAroundCenter(finger.second.curr, TOUCH_POINT_RADIUS);
-        g_pHyprRenderer->damageBox(&dmg);
-
         g_pHyprOpenGL->renderTexture(this->texture, &dmg, 1.f, 0, true);
     }
 }

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,62 +1,8 @@
-// OpenGL utility functions are copied from https://github.com/hyprwm/hyprland-plugins
-// under BSD 3-Clause License. A copy of the license can be found in the LICENSE file
-
 #include "src/devices/ITouch.hpp"
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Shaders.hpp>
 #include <utility>
 #include <vector>
-
-GLuint CompileShader(const GLuint& type, std::string src) {
-    auto shader = glCreateShader(type);
-
-    auto shaderSource = src.c_str();
-
-    glShaderSource(shader, 1, (const GLchar**)&shaderSource, nullptr);
-    glCompileShader(shader);
-
-    GLint ok;
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
-
-    if (ok == GL_FALSE)
-        throw std::runtime_error("compileShader() failed!");
-
-    return shader;
-}
-
-GLuint CreateProgram(const std::string& vert, const std::string& frag) {
-    auto vertCompiled = CompileShader(GL_VERTEX_SHADER, vert);
-
-    if (!vertCompiled)
-        throw std::runtime_error("Compiling vshader failed.");
-
-    auto fragCompiled = CompileShader(GL_FRAGMENT_SHADER, frag);
-
-    if (!fragCompiled)
-        throw std::runtime_error("Compiling fshader failed.");
-
-    auto prog = glCreateProgram();
-    glAttachShader(prog, vertCompiled);
-    glAttachShader(prog, fragCompiled);
-    glLinkProgram(prog);
-
-    glDetachShader(prog, vertCompiled);
-    glDetachShader(prog, fragCompiled);
-    glDeleteShader(vertCompiled);
-    glDeleteShader(fragCompiled);
-
-    GLint ok;
-    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
-
-    if (ok == GL_FALSE)
-        throw std::runtime_error("createProgram() failed! GL_LINK_STATUS not OK!");
-
-    return prog;
-}
-
-const std::string vertexShaderSource = R"#(
-
-)#";
 
 class Visualizer {
   public:

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -3,8 +3,7 @@
 #include <cairo/cairo.h>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Shaders.hpp>
-#include <utility>
-#include <vector>
+#include <unordered_map>
 
 class Visualizer {
   public:
@@ -23,6 +22,6 @@ class Visualizer {
     cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
     const int TOUCH_POINT_RADIUS = 15;
-    std::vector<std::pair<int32_t, Vector2D>> finger_positions;
-    std::vector<std::pair<int32_t, Vector2D>> prev_finger_positions;
+    std::unordered_map<int32_t, Vector2D> finger_positions;
+    std::unordered_map<int32_t, Vector2D> prev_finger_positions;
 };

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,9 +1,9 @@
 #include "src/devices/ITouch.hpp"
-#include "src/helpers/memory/SharedPtr.hpp"
 #include "src/render/Texture.hpp"
 #include <cairo/cairo.h>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Shaders.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
 #include <unordered_map>
 
 class Visualizer {

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,4 +1,6 @@
 #include "src/devices/ITouch.hpp"
+#include "src/render/Texture.hpp"
+#include <cairo/cairo.h>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Shaders.hpp>
 #include <utility>
@@ -6,17 +8,21 @@
 
 class Visualizer {
   public:
+    Visualizer();
+    ~Visualizer();
     void onRender();
     void damageAll();
-    void damageFinger(uint64_t id);
+    void damageFinger(int32_t id);
 
     void onTouchDown(ITouch::SDownEvent);
     void onTouchUp(ITouch::SUpEvent);
     void onTouchMotion(ITouch::SMotionEvent);
 
   private:
+    CTexture texture;
+    cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
     const int TOUCH_POINT_RADIUS = 15;
-    std::vector<std::pair<uint64_t, Vector2D>> finger_positions;
-    std::vector<std::pair<uint64_t, Vector2D>> prev_finger_positions;
+    std::vector<std::pair<int32_t, Vector2D>> finger_positions;
+    std::vector<std::pair<int32_t, Vector2D>> prev_finger_positions;
 };

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,4 +1,5 @@
 #include "src/devices/ITouch.hpp"
+#include "src/helpers/memory/SharedPtr.hpp"
 #include "src/render/Texture.hpp"
 #include <cairo/cairo.h>
 #include <hyprland/src/render/OpenGL.hpp>
@@ -18,7 +19,7 @@ class Visualizer {
     void onTouchMotion(ITouch::SMotionEvent);
 
   private:
-    CTexture texture;
+    SP<CTexture> texture = makeShared<CTexture>();
     cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
     const int TOUCH_POINT_RADIUS = 15;

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -10,7 +10,6 @@
 struct FingerPos {
     Vector2D curr;
     std::optional<Vector2D> last_rendered;
-    std::optional<Vector2D> last_rendered2;
 };
 
 class Visualizer {

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -4,12 +4,20 @@
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Shaders.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
+#include <optional>
 #include <unordered_map>
+
+struct FingerPos {
+    Vector2D curr;
+    std::optional<Vector2D> last_rendered;
+    std::optional<Vector2D> last_rendered2;
+};
 
 class Visualizer {
   public:
     Visualizer();
     ~Visualizer();
+    void onPreRender();
     void onRender();
     void damageFinger(int32_t id);
 
@@ -22,6 +30,5 @@ class Visualizer {
     cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
     const int TOUCH_POINT_RADIUS = 30;
-    std::unordered_map<int32_t, Vector2D> finger_positions;
-    std::unordered_map<int32_t, Vector2D> prev_finger_positions;
+    std::unordered_map<int32_t, FingerPos> finger_positions;
 };

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -22,7 +22,7 @@ class Visualizer {
     SP<CTexture> texture = makeShared<CTexture>();
     cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
-    const int TOUCH_POINT_RADIUS = 15;
+    const int TOUCH_POINT_RADIUS = 30;
     std::unordered_map<int32_t, Vector2D> finger_positions;
     std::unordered_map<int32_t, Vector2D> prev_finger_positions;
 };

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,0 +1,76 @@
+// OpenGL utility functions are copied from https://github.com/hyprwm/hyprland-plugins
+// under BSD 3-Clause License. A copy of the license can be found in the LICENSE file
+
+#include "src/devices/ITouch.hpp"
+#include <hyprland/src/render/OpenGL.hpp>
+#include <hyprland/src/render/Shaders.hpp>
+#include <utility>
+#include <vector>
+
+GLuint CompileShader(const GLuint& type, std::string src) {
+    auto shader = glCreateShader(type);
+
+    auto shaderSource = src.c_str();
+
+    glShaderSource(shader, 1, (const GLchar**)&shaderSource, nullptr);
+    glCompileShader(shader);
+
+    GLint ok;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+
+    if (ok == GL_FALSE)
+        throw std::runtime_error("compileShader() failed!");
+
+    return shader;
+}
+
+GLuint CreateProgram(const std::string& vert, const std::string& frag) {
+    auto vertCompiled = CompileShader(GL_VERTEX_SHADER, vert);
+
+    if (!vertCompiled)
+        throw std::runtime_error("Compiling vshader failed.");
+
+    auto fragCompiled = CompileShader(GL_FRAGMENT_SHADER, frag);
+
+    if (!fragCompiled)
+        throw std::runtime_error("Compiling fshader failed.");
+
+    auto prog = glCreateProgram();
+    glAttachShader(prog, vertCompiled);
+    glAttachShader(prog, fragCompiled);
+    glLinkProgram(prog);
+
+    glDetachShader(prog, vertCompiled);
+    glDetachShader(prog, fragCompiled);
+    glDeleteShader(vertCompiled);
+    glDeleteShader(fragCompiled);
+
+    GLint ok;
+    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+
+    if (ok == GL_FALSE)
+        throw std::runtime_error("createProgram() failed! GL_LINK_STATUS not OK!");
+
+    return prog;
+}
+
+const std::string vertexShaderSource = R"#(
+
+)#";
+
+class Visualizer {
+  public:
+    void onRender();
+    void damageAll();
+    void damageFinger(uint64_t id);
+
+    void onTouchDown(ITouch::SDownEvent);
+    void onTouchUp(ITouch::SUpEvent);
+    void onTouchMotion(ITouch::SMotionEvent);
+
+  private:
+    bool tempDamaged             = false;
+    const int TOUCH_POINT_RADIUS = 15;
+    std::vector<std::pair<uint64_t, Vector2D>> finger_positions;
+    std::vector<std::pair<uint64_t, Vector2D>> prev_finger_positions;
+};

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -11,7 +11,6 @@ class Visualizer {
     Visualizer();
     ~Visualizer();
     void onRender();
-    void damageAll();
     void damageFinger(int32_t id);
 
     void onTouchDown(ITouch::SDownEvent);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "src/SharedDefs.hpp"
 #include "version.hpp"
 
+#include <any>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/debug/Log.hpp>
@@ -129,7 +130,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe",
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch",
-                                Hyprlang::CConfigValue((Hyprlang::INT)0));
+                                Hyprlang::CConfigValue((Hyprlang::INT)1));
 #pragma GCC diagnostic pop
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});
@@ -161,6 +162,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     static auto P1 = HyprlandAPI::registerCallbackDynamic(PHANDLE, "touchDown", hkOnTouchDown);
     static auto P2 = HyprlandAPI::registerCallbackDynamic(PHANDLE, "touchUp", hkOnTouchUp);
     static auto P3 = HyprlandAPI::registerCallbackDynamic(PHANDLE, "touchMove", hkOnTouchMove);
+    static auto P4 = HyprlandAPI::registerCallbackDynamic(
+        PHANDLE, "render", [](void*, SCallbackInfo, std::any arg) { onRenderStage(std::any_cast<eRenderStage>(arg)); });
 
     HyprlandAPI::reloadConfig();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,15 +47,11 @@ static void onPreConfigReload() {
 }
 
 void onRenderStage(eRenderStage stage) {
-    static auto const LONG_PRESS_DELAY =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch")
-            ->getDataStaticPtr();
-
-    if (stage != RENDER_LAST_MOMENT || !**LONG_PRESS_DELAY) {
-        return;
+    if (stage == RENDER_PRE) {
+        g_pVisualizer->onPreRender();
+    } else if (stage == RENDER_LAST_MOMENT) {
+        g_pVisualizer->onRender();
     }
-
-    g_pVisualizer->onRender();
 }
 
 void listInternalBinds(std::string) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                                 Hyprlang::CConfigValue((Hyprlang::INT)1));
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe",
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch",
+                                Hyprlang::CConfigValue((Hyprlang::INT)0));
 #pragma GCC diagnostic pop
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ void onRenderStage(eRenderStage stage) {
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch")
             ->getDataStaticPtr();
 
-    if (stage != RENDER_LAST_MOMENT || **LONG_PRESS_DELAY) {
+    if (stage != RENDER_LAST_MOMENT || !**LONG_PRESS_DELAY) {
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,21 +24,36 @@ inline std::unique_ptr<Visualizer> g_pVisualizer;
 void hkOnTouchDown(void* _, SCallbackInfo& cbinfo, std::any e) {
     auto ev = std::any_cast<ITouch::SDownEvent>(e);
 
-    g_pVisualizer->onTouchDown(ev);
+    static auto const VISUALIZE =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch")
+            ->getDataStaticPtr();
+
+    if (**VISUALIZE)
+        g_pVisualizer->onTouchDown(ev);
     cbinfo.cancelled = g_pGestureManager->onTouchDown(ev);
 }
 
 void hkOnTouchUp(void* _, SCallbackInfo& cbinfo, std::any e) {
     auto ev = std::any_cast<ITouch::SUpEvent>(e);
 
-    g_pVisualizer->onTouchUp(ev);
+    static auto const VISUALIZE =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch")
+            ->getDataStaticPtr();
+
+    if (**VISUALIZE)
+        g_pVisualizer->onTouchUp(ev);
     cbinfo.cancelled = g_pGestureManager->onTouchUp(ev);
 }
 
 void hkOnTouchMove(void* _, SCallbackInfo& cbinfo, std::any e) {
     auto ev = std::any_cast<ITouch::SMotionEvent>(e);
 
-    g_pVisualizer->onTouchMotion(ev);
+    static auto const VISUALIZE =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch")
+            ->getDataStaticPtr();
+
+    if (**VISUALIZE)
+        g_pVisualizer->onTouchMotion(ev);
     cbinfo.cancelled = g_pGestureManager->onTouchMove(ev);
 }
 
@@ -47,9 +62,11 @@ static void onPreConfigReload() {
 }
 
 void onRenderStage(eRenderStage stage) {
-    if (stage == RENDER_PRE) {
-        g_pVisualizer->onPreRender();
-    } else if (stage == RENDER_LAST_MOMENT) {
+    static auto const VISUALIZE =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch")
+            ->getDataStaticPtr();
+
+    if (stage == RENDER_LAST_MOMENT && **VISUALIZE) {
         g_pVisualizer->onRender();
     }
 }
@@ -126,7 +143,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:emulate_touchpad_swipe",
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch",
-                                Hyprlang::CConfigValue((Hyprlang::INT)1));
+                                Hyprlang::CConfigValue((Hyprlang::INT)0));
 #pragma GCC diagnostic pop
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,8 +124,6 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:workspace_swipe_fingers",
                                 Hyprlang::CConfigValue((Hyprlang::INT)3));
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:workspace_swipe_edge",
@@ -144,13 +142,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:touch_gestures:debug:visualize_touch",
                                 Hyprlang::CConfigValue((Hyprlang::INT)0));
-#pragma GCC diagnostic pop
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bind", onNewBind, Hyprlang::SHandlerOptions{});
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprgrass-bindm", onNewBind, Hyprlang::SHandlerOptions{});
     static auto P0 = HyprlandAPI::registerCallbackDynamic(
-        PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) {
-        onPreConfigReload(); });
+        PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) { onPreConfigReload(); });
 
     HyprlandAPI::addDispatcher(PHANDLE, "touchBind", [&](std::string args) {
         HyprlandAPI::addNotification(

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ shared_module('hyprgrass',
   'main.cpp',
   'GestureManager.cpp',
   'VecSet.cpp',
+  'TouchVisualizer.cpp',
   cpp_args: ['-DWLR_USE_UNSTABLE'],
   link_with: [gestures],
   dependencies: [


### PR DESCRIPTION
- **add visualize_touch config value**
- **add basic TouchVisualizer class**
- **remove unused**
- **meson: build Visualizer**
- **visualizer: try to draw something**
- **main: wire up visualizer**
- **dumb moment**
- **add render hook**
- **FINALLY DRAWS SOMETHING**
- **remove debug log**
- **fix: circle**
- **fix: hl breaking changes**
- **nix: export inputs for debugging**
- **tweak numbers**
- **fix: use monitor pixel size**
- **draw all fingers**
- **fix: renamed upstream header**
- **damage finger on touch events**
- **remove unused damageAll**
- **render texture only in ctor**
- **pre-determine pixel coords on touch events**
- **hook prerender**
- **adapt upstream breaking changes**
- **move damage out of prerender**
- **damage monitor cuz i can't be arsed anymore**
- **fix: check config before visualize**
- **remove outdated diagnostic hints**
