### PR TITLE
Chore update pin

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -18,6 +18,7 @@ commit_pins = [
     ["12f9a0d0b93f691d4d9923716557154d74777b0a", "cb929099477407116031010905ce439db771dd62"], # v0.45.2
     ["320144ae7288fe23686935ebb235d9fe0c900862", "0c2c3dc676cee437cece6cca67965bbaba0e45b5"], # CColor -> CHyprColor
     ["8bbeee11734d3ba8e2cf15d19cb3c302f8bfdbf2", "b0c1287d571e829adf0b9fe17677c9e7c4277703"], # clang-tidy
+    ["254fc2bc6000075f660b4b8ed818a6af544d1d64", "9df724651ea92fc0c90ec55e0ef66048c9f76b57"], # v0.46.1
     ## DO NOT EDIT THIS LINE: for auto pin script ##
 ]
 

--- a/scripts/ci/pin-latest-hyprland
+++ b/scripts/ci/pin-latest-hyprland
@@ -52,7 +52,7 @@ commitPin="$("$SCRIPT_DIR/test-pin.sh" "$hlTag" "$HYPRGRASS_REV")"
 echoerr "pin tests passed: $commitPin"
 echoerr 'updating hyprpm.toml'
 
-sed -i "/## DO NOT EDIT THIS LINE: for auto pin script ##/ i    $commitPin" \
+sed -i "/## DO NOT EDIT THIS LINE: for auto pin script ##/ i\    $commitPin" \
     hyprpm.toml
 
 echoerr 'done updating hyprpm.toml'


### PR DESCRIPTION
I ran into a gcc bug trying to build against v0.46.0 so I guess we're skipping that :/

I can't be bothered to check but if v0.46.0 is good against current main just let me know and I'll add a pin