### PR TITLE
build: improve nix versioning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,16 +14,20 @@
     inherit inputs;
 
     packages = withPkgsFor (system: pkgs: let
+      tag = pkgs.lib.replaceStrings ["\n" "v"] ["" ""] (builtins.readFile ./VERSION);
+      commit = self.shortRev or "dirty";
+
       hyprgrassPackage = pkgs.callPackage ./nix/default.nix {
         inherit (hyprland.packages.${system}) hyprland;
         inherit (self.packages.${system}) wf-touch;
+        inherit tag commit;
       };
     in {
       inherit inputs;
       default = hyprgrassPackage;
       hyprgrass = hyprgrassPackage;
       hyprgrassWithTests = hyprgrassPackage.override {runTests = true;};
-      hyprgrass-pulse = pkgs.callPackage ./nix/hyprgrass-pulse.nix {};
+      hyprgrass-pulse = pkgs.callPackage ./nix/hyprgrass-pulse.nix {inherit tag commit;};
       wf-touch = pkgs.callPackage ./nix/wf-touch.nix {};
     });
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,31 +8,32 @@
   hyprland,
   wf-touch,
   doctest,
+  tag,
+  commit,
   runTests ? false,
-}: let
-  version = builtins.readFile ../VERSION;
-in
-  gcc14Stdenv.mkDerivation {
-    pname = "hyprgrass";
-    inherit version;
-    src = ./..;
+  ...
+}:
+gcc14Stdenv.mkDerivation {
+  pname = "hyprgrass";
+  version = "${tag}+${commit}";
+  src = ./..;
 
-    nativeBuildInputs =
-      hyprland.nativeBuildInputs
-      ++ [cmake ninja meson pkg-config]
-      ++ lib.optional runTests doctest;
+  nativeBuildInputs =
+    hyprland.nativeBuildInputs
+    ++ [cmake ninja meson pkg-config]
+    ++ lib.optional runTests doctest;
 
-    buildInputs = [hyprland wf-touch doctest] ++ hyprland.buildInputs;
+  buildInputs = [hyprland wf-touch doctest] ++ hyprland.buildInputs;
 
-    doCheck = true;
+  doCheck = true;
 
-    # CMake is just used for finding doctest.
-    dontUseCmakeConfigure = true;
+  # CMake is just used for finding doctest.
+  dontUseCmakeConfigure = true;
 
-    meta = with lib; {
-      homepage = "https://github.com/horriblename/hyprgrass";
-      description = "Hyprland plugin for touch gestures";
-      license = licenses.bsd3;
-      platforms = platforms.linux;
-    };
-  }
+  meta = with lib; {
+    homepage = "https://github.com/horriblename/hyprgrass";
+    description = "Hyprland plugin for touch gestures";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}

--- a/nix/hyprgrass-pulse.nix
+++ b/nix/hyprgrass-pulse.nix
@@ -6,32 +6,33 @@
   pkg-config,
   hyprland,
   libpulseaudio,
-}: let
-  version = builtins.readFile ../VERSION;
-in
-  gcc14Stdenv.mkDerivation {
-    pname = "hyprgrass-pulse";
-    inherit version;
-    src = ./..;
+  tag,
+  commit,
+  ...
+}:
+gcc14Stdenv.mkDerivation {
+  pname = "hyprgrass-pulse";
+  version = "${tag}+${commit}";
+  src = ./..;
 
-    nativeBuildInputs =
-      hyprland.nativeBuildInputs
-      ++ [ninja meson pkg-config];
+  nativeBuildInputs =
+    hyprland.nativeBuildInputs
+    ++ [ninja meson pkg-config];
 
-    buildInputs = [hyprland libpulseaudio] ++ hyprland.buildInputs;
+  buildInputs = [hyprland libpulseaudio] ++ hyprland.buildInputs;
 
-    mesonFlags = [
-      "-Dhyprgrass=false"
-      "-Dhyprgrass-pulse=true"
-      "-Dtests=disabled"
-    ];
+  mesonFlags = [
+    "-Dhyprgrass=false"
+    "-Dhyprgrass-pulse=true"
+    "-Dtests=disabled"
+  ];
 
-    doCheck = true;
+  doCheck = true;
 
-    meta = with lib; {
-      homepage = "https://github.com/horriblename/hyprgrass";
-      description = "Hyprgrass extension to control audio volume";
-      license = licenses.bsd3;
-      platforms = platforms.linux;
-    };
-  }
+  meta = with lib; {
+    homepage = "https://github.com/horriblename/hyprgrass";
+    description = "Hyprgrass extension to control audio volume";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Make the version of nix packages more inline with what is expected by nix tools.

For example, `nix-output-monitor`:

Before:

![image](https://github.com/user-attachments/assets/5d8e7329-6554-4c1e-8d4c-52b7c8a7c897)

After:

![image](https://github.com/user-attachments/assets/7c3e542e-b847-43e7-b2da-a96a61e30820)

This also allows [nvd](https://git.sr.ht/~khumba/nvd) to correctly parse version changes