### PR TITLE
Nix code cleanup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,12 @@
     hyprland,
   } @ inputs: let
     inherit (hyprland.inputs) nixpkgs;
-    withPkgsFor = fn: nixpkgs.lib.genAttrs (builtins.attrNames hyprland.packages) (system: fn system nixpkgs.legacyPackages.${system});
+    withPkgsFor = fn:
+      nixpkgs.lib.genAttrs (builtins.attrNames hyprland.packages) (system:
+        fn system (import nixpkgs {
+          inherit system;
+          overlays = [hyprland.overlays.hyprland-packages];
+        }));
   in {
     # for debugging
     inherit inputs;

--- a/flake.nix
+++ b/flake.nix
@@ -36,17 +36,19 @@
       wf-touch = pkgs.callPackage ./nix/wf-touch.nix {};
     });
 
-    devShells = withPkgsFor (system: pkgs: {
-      default = pkgs.mkShell.override {stdenv = pkgs.gcc14Stdenv;} {
+    devShells = withPkgsFor (system: pkgs: let
+      hyprlandPkgs = hyprland.packages.${system};
+    in {
+      default = pkgs.mkShell.override {inherit (hyprlandPkgs.hyprland) stdenv;} {
         shellHook = ''
           meson setup build -Dhyprgrass-pulse=true --reconfigure
           sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
         '';
         name = "hyprgrass-shell";
         nativeBuildInputs = with pkgs; [meson pkg-config ninja];
-        buildInputs = [hyprland.packages.${system}.hyprland pkgs.libpulseaudio];
+        buildInputs = [hyprlandPkgs.hyprland pkgs.libpulseaudio];
         inputsFrom = [
-          hyprland.packages.${system}.hyprland
+          hyprlandPkgs.hyprland
           self.packages.${system}.default
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -32,13 +32,13 @@
     });
 
     devShells = withPkgsFor (system: pkgs: {
-      default = pkgs.mkShell {
+      default = pkgs.mkShell.override {stdenv = pkgs.gcc14Stdenv;} {
         shellHook = ''
           meson setup build -Dhyprgrass-pulse=true --reconfigure
           sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
         '';
         name = "hyprgrass-shell";
-        nativeBuildInputs = with pkgs; [gcc14 meson pkg-config ninja];
+        nativeBuildInputs = with pkgs; [meson pkg-config ninja];
         buildInputs = [hyprland.packages.${system}.hyprland pkgs.libpulseaudio];
         inputsFrom = [
           hyprland.packages.${system}.hyprland

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  gcc14Stdenv,
   cmake,
   meson,
   ninja,
-  pkg-config,
   hyprland,
+  hyprlandPlugins,
   wf-touch,
   doctest,
   tag,
@@ -13,17 +12,14 @@
   runTests ? false,
   ...
 }:
-gcc14Stdenv.mkDerivation {
-  pname = "hyprgrass";
+hyprlandPlugins.mkHyprlandPlugin hyprland {
+  pluginName = "hyprgrass";
   version = "${tag}+${commit}";
   src = ./..;
 
-  nativeBuildInputs =
-    hyprland.nativeBuildInputs
-    ++ [cmake ninja meson pkg-config]
-    ++ lib.optional runTests doctest;
+  nativeBuildInputs = [cmake ninja meson] ++ lib.optional runTests doctest;
 
-  buildInputs = [hyprland wf-touch doctest] ++ hyprland.buildInputs;
+  buildInputs = [wf-touch doctest];
 
   doCheck = true;
 

--- a/nix/hyprgrass-pulse.nix
+++ b/nix/hyprgrass-pulse.nix
@@ -1,25 +1,23 @@
 {
   lib,
-  gcc14Stdenv,
   meson,
   ninja,
   pkg-config,
   hyprland,
+  hyprlandPlugins,
   libpulseaudio,
   tag,
   commit,
   ...
 }:
-gcc14Stdenv.mkDerivation {
-  pname = "hyprgrass-pulse";
+hyprlandPlugins.mkHyprlandPlugin hyprland {
+  pluginName = "hyprgrass-pulse";
   version = "${tag}+${commit}";
   src = ./..;
 
-  nativeBuildInputs =
-    hyprland.nativeBuildInputs
-    ++ [ninja meson pkg-config];
+  nativeBuildInputs = [ninja meson pkg-config];
 
-  buildInputs = [hyprland libpulseaudio] ++ hyprland.buildInputs;
+  buildInputs = [libpulseaudio];
 
   mesonFlags = [
     "-Dhyprgrass=false"


### PR DESCRIPTION
- instead of using a specific stdenv in multiple places, I just use hyprland's
- add hyprland overlays in `withPkgsFor`
- replace `gcc14Stdenv.mkDerivation` with `hyprlandPlugins.mkHyprlandPlugin`