### PR TITLE
Allow 1 and 2-finger swipes/taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,10 @@ where (skip to [examples](#examples) if this is confusing):
 
 - `gesture_name` is one of:
   1. `swipe:<finger_count>:<direction>`
-     - `finger_count` must be >= 3
+     - `finger_count`
      - `direction` is one of `l`, `r`, `u`, `d`, or `ld`, `rd`, `lu`, `ru` for diagonal directions.  
        (l, r, u, d stand for left, right, up, down)
   2. `tap:<finger_count>`
-     - `finger_count` must be >= 3
   3. `edge:<from_edge>:<direction>`
      - `<from_edge>` is from which edge to start from (l/r/u/d)
      - `<direction>` is in which direction to swipe (l/r/u/d/lu/ld/ru/rd)
@@ -214,7 +213,6 @@ plugin {
         hyprgrass-bind = , edge:l:d, exec, pactl set-sink-volume @DEFAULT_SINK@ -4%
 
         # swipe down with 4 fingers
-        # NOTE: swipe events only trigger for finger count of >= 3
         hyprgrass-bind = , swipe:4:d, killactive
 
         # swipe diagonally left and down with 3 fingers
@@ -222,7 +220,6 @@ plugin {
         hyprgrass-bind = , swipe:3:ld, exec, foot
 
         # tap with 3 fingers
-        # NOTE: tap events only trigger for finger count of >= 3
         hyprgrass-bind = , tap:3, exec, foot
 
         # longpress can trigger mouse binds:

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     in {
       default = pkgs.mkShell.override {inherit (hyprlandPkgs.hyprland) stdenv;} {
         shellHook = ''
-          meson setup build -Dhyprgrass-pulse=true --reconfigure
+          meson setup build -Dbuildtype=debug -Dhyprgrass-pulse=true --reconfigure
           sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
         '';
         name = "hyprgrass-shell";

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -86,10 +86,10 @@ GestureManager::GestureManager() : IGestureManager(std::make_unique<HyprLogger>(
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:touch_gestures:edge_margin")
             ->getDataStaticPtr();
 
+    this->addEdgeSwipeGesture(*PSENSITIVITY, *LONG_PRESS_DELAY, *EDGE_MARGIN);
+    this->addLongPress(*PSENSITIVITY, *LONG_PRESS_DELAY);
     this->addMultiFingerGesture(*PSENSITIVITY, *LONG_PRESS_DELAY);
     this->addMultiFingerTap(*PSENSITIVITY, *LONG_PRESS_DELAY);
-    this->addLongPress(*PSENSITIVITY, *LONG_PRESS_DELAY);
-    this->addEdgeSwipeGesture(*PSENSITIVITY, *LONG_PRESS_DELAY, *EDGE_MARGIN);
 
     this->long_press_timer = wl_event_loop_add_timer(g_pCompositor->m_sWLEventLoop, handleLongPressTimer, this);
 }

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -348,8 +348,8 @@ bool GestureManager::handleWorkspaceSwipe(const GestureDirection direction) {
     const bool VERTANIMS =
         g_pCompositor->m_pLastMonitor->activeWorkspace->m_vRenderOffset->getConfig()->pValues->internalStyle ==
             "slidevert" ||
-        g_pCompositor->m_pLastMonitor->activeWorkspace->m_vRenderOffset->getConfig()->pValues->internalStyle.starts_with(
-            "slidevert");
+        g_pCompositor->m_pLastMonitor->activeWorkspace->m_vRenderOffset->getConfig()
+            ->pValues->internalStyle.starts_with("slidevert");
 
     const auto horizontal           = GESTURE_DIRECTION_LEFT | GESTURE_DIRECTION_RIGHT;
     const auto vertical             = GESTURE_DIRECTION_UP | GESTURE_DIRECTION_DOWN;

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -122,10 +122,6 @@ void IGestureManager::addTouchGesture(std::unique_ptr<wf::touch::gesture_t> gest
 }
 
 void IGestureManager::addMultiFingerGesture(const float* sensitivity, const int64_t* timeout) {
-    auto multi_down_and_send_cancel = std::make_unique<OnCompleteAction>(
-        std::make_unique<MultiFingerDownAction>(), [this]() { this->cancelTouchEventsOnAllWindows(); });
-    multi_down_and_send_cancel->set_duration(GESTURE_BASE_DURATION);
-
     auto swipe = std::make_unique<CMultiAction>(SWIPE_INCORRECT_DRAG_TOLERANCE, sensitivity, timeout);
 
     auto swipe_ptr = swipe.get();
@@ -143,10 +139,8 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity, const int6
     });
 
     auto swipe_liftoff = std::make_unique<LiftoffAction>();
-    // swipe_liftoff->set_duration(GESTURE_BASE_DURATION / 2);
 
     std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
-    swipe_actions.emplace_back(std::move(multi_down_and_send_cancel));
     swipe_actions.emplace_back(std::move(swipe_and_emit));
     swipe_actions.emplace_back(std::move(swipe_liftoff));
 

--- a/src/gestures/Gestures.hpp
+++ b/src/gestures/Gestures.hpp
@@ -81,6 +81,7 @@ class IGestureManager {
   private:
     std::unique_ptr<Logger> logger;
     bool inhibitTouchEvents;
+    bool gestureTriggered; // A drag/completed gesture is triggered
     std::optional<DragGestureEvent> activeDragGesture;
 
     // this function is called when needed to send "cancel touch" events to

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -112,7 +112,10 @@ using TouchEvent = wf::touch::gesture_event_t;
 using wf::touch::point_t;
 
 TEST_CASE("Multifinger: block touch events to client surfaces when more than a "
-          "certain number of fingers touch down.") {
+          "certain number of fingers touch down." *
+          // multi-finger used to cancel touch events on 3 finger touch down
+          // currently removed but may bring it back
+          doctest::should_fail()) {
     std::cout << "  ==== stdout:" << std::endl;
     auto gm = CMockGestureManager::newCompletedGestureOnlyHandler();
     gm.addMultiFingerGesture(&SENSITIVITY, &LONG_PRESS_DELAY);

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -314,15 +314,15 @@ TEST_CASE("Edge Swipe: Complete upon: \n"
 }
 
 // haven't gotten around to checking what's wrong
-TEST_CASE("Edge Swipe: Timeout during swiping phase" * doctest::may_fail(true)) {
+TEST_CASE("Edge Swipe: Timeout during swiping phase") {
     std::cout << "  ==== stdout:" << std::endl;
     auto gm = CMockGestureManager::newCompletedGestureOnlyHandler();
     gm.addEdgeSwipeGesture(&SENSITIVITY, &LONG_PRESS_DELAY, &EDGE_MARGIN);
 
     const std::vector<TouchEvent> events{
         {wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {5, 300}},
-        {wf::touch::EVENT_TYPE_MOTION, 150, 0, {300, 300}},
-        {wf::touch::EVENT_TYPE_MOTION, 520, 0, {600, 300}},
+        {wf::touch::EVENT_TYPE_MOTION, 150, 0, {154, 300}},
+        {wf::touch::EVENT_TYPE_MOTION, 551, 0, {600, 300}},
     };
     ProcessEvents(gm, {.type = ExpectResultType::CANCELLED}, events);
 }


### PR DESCRIPTION
Motivation: this should make hyprgrass a more "complete" solution for other plugins to use (via
event hooks)

- No longer sends cancel event to windows on three finger touch down (still sends cancel on a valid
  swipe/hold/etc.)
  - the arbitrary limit doesn't make much sense and might break applications that use 3-finger 
    gestures.
