### PR TITLE
refactor: clean up includes

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -1,34 +1,16 @@
 #include "GestureManager.hpp"
-#include "gestures/Shared.hpp"
+#include "HyprLogger.hpp"
 #include "globals.hpp"
-#include "src/managers/SessionLockManager.hpp"
-#include "wayfire/touch/touch.hpp"
-#include <algorithm>
-#include <cstdint>
-#include <glm/detail/qualifier.hpp>
-#include <hyprutils/math/Vector2D.hpp>
-#include <hyprutils/memory/SharedPtr.hpp>
-#include <string>
 
 #define private public
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
-#include <hyprland/src/debug/Log.hpp>
-#include <hyprland/src/devices/ITouch.hpp>
 #include <hyprland/src/managers/HookSystemManager.hpp>
-#include <hyprland/src/managers/KeybindManager.hpp>
-#include <hyprland/src/managers/LayoutManager.hpp>
 #include <hyprland/src/managers/SeatManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/protocols/core/Compositor.hpp>
-#include <hyprland/src/protocols/core/Seat.hpp>
 #undef private
 
-#include <algorithm>
-#include <hyprlang.hpp>
-#include <memory>
-#include <optional>
 #include <ranges>
 
 // constexpr double SWIPE_THRESHOLD = 30.;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -1,22 +1,12 @@
 #pragma once
 #include "./gestures/Gestures.hpp"
-#include "HyprLogger.hpp"
 #include "VecSet.hpp"
-#include "gestures/Shared.hpp"
-#include <memory>
 
 #define private public
 #include <hyprland/src/config/ConfigDataValues.hpp>
-#include <hyprland/src/debug/Log.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
-#include <hyprland/src/helpers/Monitor.hpp>
-#include <hyprland/src/includes.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
-#include <hyprland/src/protocols/core/Seat.hpp>
 #undef private
-
-#include <wayfire/touch/touch.hpp>
-#include <wayland-server-core.h>
 
 class GestureManager : public IGestureManager {
   public:

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -1,12 +1,6 @@
 #include "TouchVisualizer.hpp"
-#include "src/devices/ITouch.hpp"
-#include "src/macros.hpp"
-#include "src/render/OpenGL.hpp"
-#include "src/render/Renderer.hpp"
-#include <cairo/cairo.h>
+#include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/SharedDefs.hpp>
-#include <optional>
 
 CBox boxAroundCenter(Vector2D center, double radius) {
     return CBox(center.x - radius, center.y - radius, 2 * radius, 2 * radius);

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,11 +1,6 @@
-#include "src/devices/ITouch.hpp"
-#include "src/render/Texture.hpp"
+#include <hyprland/src/devices/ITouch.hpp>
+#include <hyprland/src/render/Texture.hpp>
 #include <cairo/cairo.h>
-#include <hyprland/src/render/OpenGL.hpp>
-#include <hyprland/src/render/Shaders.hpp>
-#include <hyprutils/memory/SharedPtr.hpp>
-#include <optional>
-#include <unordered_map>
 
 struct FingerPos {
     Vector2D curr;

--- a/src/VecSet.hpp
+++ b/src/VecSet.hpp
@@ -1,6 +1,4 @@
 #include <vector>
-
-#include <hyprland/src/helpers/memory/Memory.hpp>
 #include <hyprland/src/protocols/core/Seat.hpp>
 
 // Probably not compatible with move semantics, I really don't know

--- a/src/gestures/Actions.hpp
+++ b/src/gestures/Actions.hpp
@@ -1,7 +1,6 @@
 #include "Shared.hpp"
 #include <functional>
 #include <memory>
-#include <optional>
 #include <wayfire/touch/touch.hpp>
 
 using UpdateExternalTimerCallback = std::function<void(uint32_t current_timer, uint32_t delay)>;


### PR DESCRIPTION
There was a build failure on latest Hyprland because of a specific include and I just removed it and it worked, so I figured I could remove all the unneeded includes to prevent that kind of problem from occurring.