### PR TITLE
Update hyprpm.toml - hypergrass-pulse added

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -47,3 +47,12 @@ build = [
     "meson setup build",
     "ninja -C build",
 ]
+
+[hyprgrass-pulse]
+description = "Hyprgras extension to control audio volume in pulse-audio"
+author = "horriblename"
+output = "build/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
+build = [
+    "meson setup build -Dhyprgrass=false -Dhyprgrass-pulse=true",
+    "ninja -C build",
+]

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -49,7 +49,7 @@ build = [
 ]
 
 [hyprgrass-pulse]
-description = "Hyprgras extension to control audio volume in pulse-audio"
+description = "Hyprgrass extension to control audio volume in pulse-audio"
 author = "horriblename"
 output = "build/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
 build = [


### PR DESCRIPTION
After reading the README.md, I've missed the option to enable hyprgrass-pulse through hyprpm. Of course it means one needs to install the pulse deps too, even if they did not plan to enable it, but hyprgrass only.

Builds sucessfuly and hyprgrass-pulse can be enabled separately

```
user@linux:~$ hyprpm enable hyprgrass-pulse
[sudo] password for attis: 
✔ Enabled hyprgrass-pulse
✔ Ensuring plugin load state
✔ Loaded hyprgrass-pulse
✔ Plugin load state ensured
user@linux:~$ hyprpm list
→ Repository hyprgrass:
  │ Plugin hyprgrass
  └─ enabled: true

  │ Plugin hyprgrass-pulse
  └─ enabled: true

→ Repository hyprland-plugins:
  │ Plugin borders-plus-plus
  └─ enabled: false
....
```