### PR TITLE
fix: broken hyprpm build (& backport to hyprload)

### DIFF
--- a/hyprload.toml
+++ b/hyprload.toml
@@ -14,8 +14,8 @@ description = "Hyprgras extension to control audio volume in pulse-audio"
 author = "horriblename"
 
 [hyprgrass-pulse]
-output = "build/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
+output = "build/pulse/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
 steps = [
-    "meson setup build -Dhyprgrass=false -Dhyprgrass-pulse=true",
-    "ninja -C build",
+    "meson setup build/pulse -Dhyprgrass=false -Dhyprgrass-pulse=true",
+    "ninja -C build/pulse",
 ]

--- a/hyprload.toml
+++ b/hyprload.toml
@@ -14,8 +14,8 @@ description = "Hyprgras extension to control audio volume in pulse-audio"
 author = "horriblename"
 
 [hyprgrass-pulse]
-output = "build/pulse/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
+output = "examples/hyprgrass-pulse/build/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
 steps = [
-    "meson setup build/pulse -Dhyprgrass=false -Dhyprgrass-pulse=true",
-    "ninja -C build/pulse",
+    "meson setup examples/hyprgrass-pulse/build -Dhyprgrass=false -Dhyprgrass-pulse=true",
+    "ninja -C examples/hyprgrass-pulse/build",
 ]

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -54,8 +54,8 @@ build = [
 [hyprgrass-pulse]
 description = "Hyprgrass extension to control audio volume in pulse-audio"
 author = "horriblename"
-output = "build/pulse/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
+output = "examples/hyprgrass-pulse/build/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
 build = [
-    "meson setup build/pulse -Dhyprgrass=false -Dhyprgrass-pulse=true",
-    "ninja -C build/pulse",
+    "meson setup examples/hyprgrass-pulse/build -Dhyprgrass=false -Dhyprgrass-pulse=true",
+    "ninja -C examples/hyprgrass-pulse/build",
 ]

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -54,8 +54,8 @@ build = [
 [hyprgrass-pulse]
 description = "Hyprgrass extension to control audio volume in pulse-audio"
 author = "horriblename"
-output = "build/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
+output = "build/pulse/examples/hyprgrass-pulse/libhyprgrass-pulse.so"
 build = [
-    "meson setup build -Dhyprgrass=false -Dhyprgrass-pulse=true",
-    "ninja -C build",
+    "meson setup build/pulse -Dhyprgrass=false -Dhyprgrass-pulse=true",
+    "ninja -C build/pulse",
 ]


### PR DESCRIPTION
There is an issue I described in #265, introduced by the addition of the second plugin `hyprgrass-pulse` to `hyprpm.toml`, preventing the plugin from working when built via hyprpm.

Apparently, when hyprpm builds a repo with multiple plugins, it runs the build commands for both, and then copies both `.so` files wherever they need to go.

So here's a dramatic reenactment of what is happening when you add this repo via `hyprpm`:
```sh
# run build commands for `hyprgrass`
meson setup build
ninja -C build
# everything's fine, the binary is in `build/src/libhyprgrass.so`

# now run build commands for `hyprgrass-pulse`
meson setup build -Dhyprgrass=false -Dhyprgrass-pulse=true # overwrites the build/ directory
ninja -C build

# built successfully

cp build/src/libhyprgrass.so /whereever/hyprpm/stores/binaries/hyprgrass.so
# WHOOPS, this has been overwritten, but reported as successfully built

cp build/examples/hyprgrass-pulse/libhyprgrass-pulse.so /whereever/hyprpm/stores/binaries/hyprgrass-pulse.so
# this one is fine
```

My proposed solution is to reconfigure and build hyprgrass-pulse in a subdir `build/pulse`, which prevents the entire `build` dir and the `hyprgrass` binary inside it from being overwritten.