### PR TITLE
ci: fix some CI errors, pin Hyprland 0.51.1

### DIFF
--- a/.github/workflows/pin-latest-hyprland.yml
+++ b/.github/workflows/pin-latest-hyprland.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * 0" # weekly on Sunday 00:00
 jobs:
-  tests:
+  pin-latest-hyprland:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -40,6 +40,7 @@ commit_pins = [
     ["c4a4c341568944bd4fb9cd503558b2de602c0213", "7dafd92afedda246a9c1c4187784c3fc1d6261e5"], # v0.50.0
     ["4e242d086e20b32951fdc0ebcbfb4d41b5be8dcc", "7dafd92afedda246a9c1c4187784c3fc1d6261e5"], # v0.50.1
     ["127aab815908ecbd3db4d23f127d2e96b79855f9", "faedd0064291c353a204ba568f52b15a3cc1aa85"], # g_pUnifiedWorkspaceSwipe
+    ["71a1216abcc7031776630a6d88f105605c4dc1c9", "ad51f4649a1c054d788fb6ce2a2bfcdfac28d524"], # v0.51.1
     ## DO NOT EDIT THIS LINE: for auto pin script ##
 ]
 

--- a/scripts/ci/test-pin.sh
+++ b/scripts/ci/test-pin.sh
@@ -36,6 +36,6 @@ nix flake update --override-input hyprland "$hlUrl"
 nix build --no-link '.#hyprgrassWithTests'
 
 cd ..
-git worktree remove "$worktreeDir"
+git worktree remove --force "$worktreeDir"
 
 echo "[\"${hyprlandCommit}\", \"${hyprgrassCommit}\"], # ${hyprlandRev}"

--- a/scripts/ci/test-pin.sh
+++ b/scripts/ci/test-pin.sh
@@ -27,15 +27,17 @@ hlUrl="github:hyprwm/Hyprland/${hyprlandRev}"
 
 worktreeDir="pin-build"
 
-git worktree add "$worktreeDir" "$hyprgrassCommit"
-cd "$worktreeDir"
+{
+	git worktree add "$worktreeDir" "$hyprgrassCommit"
+	cd "$worktreeDir"
 
-# NOTE: nix build --override-input does not override input of inputs, i.e. hyprland/aquamarine
-# will not be updated, hence we need to run `flake update` :<
-nix flake update --override-input hyprland "$hlUrl"
-nix build --no-link '.#hyprgrassWithTests'
+	# NOTE: nix build --override-input does not override input of inputs, i.e. hyprland/aquamarine
+	# will not be updated, hence we need to run `flake update` :<
+	nix flake update --override-input hyprland "$hlUrl"
+	nix build --no-link '.#hyprgrassWithTests'
 
-cd ..
-git worktree remove --force "$worktreeDir"
+	cd ..
+	git worktree remove --force "$worktreeDir"
+} >&2 # avoid cluttering stdout
 
 echo "[\"${hyprlandCommit}\", \"${hyprgrassCommit}\"], # ${hyprlandRev}"


### PR DESCRIPTION
- **ci: force remove worktree in pin script**
- **ci: fix cluttered stdout of test-pin.sh**
- **chore: pin against hyprland 0.51.1**
