### PR TITLE
fix irrelevant plugins being called in gesture update events

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
         '';
         name = "hyprgrass-shell";
         nativeBuildInputs = with pkgs; [meson pkg-config ninja];
-        buildInputs = [pkgs.hyprland pkgs.libpulseaudio];
+        buildInputs = [pkgs.hyprland pkgs.pulseaudio];
         inputsFrom = [
           pkgs.hyprland
           pkgs.hyprlandPlugins.hyprgrass

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "./gestures/Gestures.hpp"
 #include "VecSet.hpp"
+#include "src/plugins/PluginAPI.hpp"
 
 #define private public
 #include <hyprland/src/config/ConfigDataValues.hpp>
@@ -55,7 +56,7 @@ class GestureManager : public IGestureManager {
         CCssGapData old_gaps_in;
     } resizeOnBorderInfo;
     bool workspaceSwipeActive = false;
-    bool hookHandled          = false;
+    HANDLE hookHandled        = nullptr;
     wf::touch::point_t emulatedSwipePoint;
 
     bool handleGestureBind(std::string bind, GestureEventType);


### PR DESCRIPTION
- **nix: use pulseaudio instead of libpulseaudio in devShell**
- **hooks: fix hook events firing for irrelevant plugins**
