### PR TITLE
feat: bind gestures to HL trackpad 1:1 gestures

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,7 @@ BasedOnStyle: LLVM
 TabWidth: 4
 IndentWidth: 4
 UseTab: Never
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveAssignments: true
 IndentCaseLabels: true
 ColumnLimit: 120

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -1,6 +1,8 @@
 #include "GestureManager.hpp"
 #include "HyprLogger.hpp"
 #include "globals.hpp"
+#include <hyprutils/math/Vector2D.hpp>
+#include <wayfire/touch/touch.hpp>
 
 #define private public
 #include <hyprland/src/Compositor.hpp>
@@ -49,6 +51,10 @@ std::vector<std::string> splitString(const std::string& s, char delimiter, int n
     }
 
     return substrings;
+}
+
+Vector2D pointToVector(wf::touch::point_t point) {
+    return Vector2D{point.x, point.y};
 }
 
 bool emitHookEvent(std::vector<SCallbackFNPtr>* hooks, std::any param) {
@@ -137,6 +143,9 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
                 this->hookHandled = true;
                 return true;
             }
+
+            if (this->trackpadGestureBegin(gev))
+                return true;
 
             if (**WORKSPACE_SWIPE_FINGERS != gev.finger_count) {
                 return false;
@@ -306,6 +315,11 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
         return;
     }
 
+    if (g_pHyprgrassTrackpadGestures->m_activeGesture) {
+        this->trackpadGestureUpdate(ev.time);
+        return;
+    }
+
     switch (this->getActiveDragGesture()->type) {
         case DragGestureType::SWIPE:
             if (this->hookHandled) {
@@ -353,6 +367,11 @@ void GestureManager::handleDragGestureEnd(const DragGestureEvent& gev) {
 
     if (g_pSessionLockManager->isSessionLocked()) {
         this->handleGestureBind(gev.to_string(), GestureEventType::DRAG_END);
+        return;
+    }
+
+    if (g_pHyprgrassTrackpadGestures->m_activeGesture) {
+        this->trackpadGestureEnd(gev);
         return;
     }
 
@@ -414,21 +433,77 @@ bool GestureManager::handleWorkspaceSwipe(const GestureDirection direction) {
 }
 
 void GestureManager::updateWorkspaceSwipe() {
-    const auto ANIMSTYLE = g_pUnifiedWorkspaceSwipe->m_workspaceBegin->m_renderOffset->getStyle();
-    const bool VERTANIMS = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
-
-    static auto const PSWIPEDIST =
-        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "gestures:workspace_swipe_distance")
-            ->getDataStaticPtr();
-    const auto SWIPEDISTANCE = std::clamp(**PSWIPEDIST, (int64_t)1LL, (int64_t)UINT32_MAX);
-
-    const auto monArea       = this->getMonitorArea();
-    const auto delta_percent = this->m_sGestureState.get_center().delta() / wf::touch::point_t(monArea.w, monArea.h);
-
-    const auto swipe_delta = Vector2D(delta_percent.x * SWIPEDISTANCE, delta_percent.y * SWIPEDISTANCE);
+    const auto ANIMSTYLE   = g_pUnifiedWorkspaceSwipe->m_workspaceBegin->m_renderOffset->getStyle();
+    const bool VERTANIMS   = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
+    const auto swipe_delta = this->pixelToTrackpadDistance(this->m_sGestureState.get_center().delta());
 
     g_pUnifiedWorkspaceSwipe->update(VERTANIMS ? -swipe_delta.y : -swipe_delta.x);
     return;
+}
+
+bool GestureManager::trackpadGestureBegin(const DragGestureEvent& gev) {
+    Vector2D delta = pointToVector(this->m_sGestureState.get_center().delta());
+
+    switch (gev.type) {
+        case DragGestureType::SWIPE:      /*fallthrough*/
+        case DragGestureType::LONG_PRESS: /*fallthrough*/
+        case DragGestureType::EDGE_SWIPE: /*fallthrough*/
+            IPointer::SSwipeBeginEvent swipeBegin = {
+                .timeMs  = gev.time,
+                .fingers = static_cast<uint32_t>(gev.finger_count),
+            };
+            IPointer::SSwipeUpdateEvent swipe = {
+                .timeMs  = gev.time,
+                .fingers = static_cast<uint32_t>(gev.finger_count),
+                .delta   = delta,
+            };
+            g_pHyprgrassTrackpadGestures->gestureBegin(swipeBegin);
+            g_pHyprgrassTrackpadGestures->gestureUpdate(swipe);
+            this->emulatedSwipePoint = this->m_sGestureState.get_center().current;
+
+            return g_pHyprgrassTrackpadGestures->m_activeGesture;
+    }
+}
+
+void GestureManager::trackpadGestureUpdate(uint32_t time) {
+    if (!this->getActiveDragGesture())
+        return;
+
+    const auto currentPoint = this->m_sGestureState.get_center().current;
+    const auto deltaPx      = currentPoint - this->emulatedSwipePoint;
+    const Vector2D delta    = pointToVector(deltaPx);
+
+    this->emulatedSwipePoint = currentPoint;
+
+    DragGestureEvent activeDrag = this->getActiveDragGesture().value();
+
+    switch (activeDrag.type) {
+        case DragGestureType::SWIPE:      /*fallthrough*/
+        case DragGestureType::LONG_PRESS: /*fallthrough*/
+        case DragGestureType::EDGE_SWIPE: /*fallthrough*/
+            IPointer::SSwipeUpdateEvent swipe = {
+                .timeMs  = time,
+                .fingers = static_cast<uint32_t>(activeDrag.finger_count),
+                .delta   = delta,
+            };
+            g_pHyprgrassTrackpadGestures->gestureUpdate(swipe);
+
+            return;
+    }
+}
+
+void GestureManager::trackpadGestureEnd(const DragGestureEvent& gev) {
+    switch (gev.type) {
+        case DragGestureType::SWIPE:      /*fallthrough*/
+        case DragGestureType::LONG_PRESS: /*fallthrough*/
+        case DragGestureType::EDGE_SWIPE: /*fallthrough*/
+            IPointer::SSwipeEndEvent end = {
+                .timeMs    = gev.time,
+                .cancelled = false,
+            };
+            g_pHyprgrassTrackpadGestures->gestureEnd(end);
+            return;
+    }
 }
 
 void GestureManager::updateLongPressTimer(uint32_t current_time, uint32_t delay) {
@@ -608,6 +683,18 @@ wf::touch::point_t GestureManager::wlrTouchEventPositionAsPixels(double x, doubl
 Vector2D GestureManager::pixelPositionToPercentagePosition(wf::touch::point_t point) const {
     auto monitorArea = this->getMonitorArea();
     return Vector2D((point.x - monitorArea.x) / monitorArea.w, (point.y - monitorArea.y) / monitorArea.h);
+}
+
+Vector2D GestureManager::pixelToTrackpadDistance(wf::touch::point_t distancePx) const {
+    static auto const PSWIPEDIST =
+        (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "gestures:workspace_swipe_distance")
+            ->getDataStaticPtr();
+    const auto SWIPEDISTANCE = std::clamp(**PSWIPEDIST, (int64_t)1LL, (int64_t)UINT32_MAX);
+
+    const auto monArea       = this->getMonitorArea();
+    const auto delta_percent = distancePx / wf::touch::point_t(monArea.w, monArea.h);
+
+    return Vector2D(delta_percent.x * SWIPEDISTANCE, delta_percent.y * SWIPEDISTANCE);
 }
 
 void GestureManager::touchBindDispatcher(std::string args) {

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -126,9 +126,12 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
             static auto* const PEVENTVEC = g_pHookSystem->getVecForEvent("hyprgrass:swipeBegin");
 
             bool handled = emitHookEvent(
-                PEVENTVEC, std::tuple<std::string, std::uint64_t, Vector2D>{
-                               stringifyDirection(gev.direction), gev.finger_count,
-                               pixelPositionToPercentagePosition(this->m_sGestureState.get_center().origin)});
+                PEVENTVEC,
+                std::tuple<std::string, std::uint64_t, Vector2D>{
+                    stringifyDirection(gev.direction), gev.finger_count,
+                    pixelPositionToPercentagePosition(this->m_sGestureState.get_center().origin)
+                }
+            );
 
             if (handled) {
                 this->hookHandled = true;
@@ -158,7 +161,9 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
             bool handled = emitHookEvent(
                 PEVENTVEC,
                 std::pair<std::string, Vector2D>(
-                    gev.to_string(), pixelPositionToPercentagePosition(this->m_sGestureState.get_center().origin)));
+                    gev.to_string(), pixelPositionToPercentagePosition(this->m_sGestureState.get_center().origin)
+                )
+            );
 
             if (handled) {
                 this->hookHandled = true;
@@ -195,10 +200,14 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
                     pixelPositionToPercentagePosition(this->m_sGestureState.get_center().current) *
                     this->m_lastTouchedMonitor->m_size;
                 if (w && !w->isFullscreen()) {
-                    const CBox real = {w->m_realPosition->value().x, w->m_realPosition->value().y,
-                                       w->m_realSize->value().x, w->m_realSize->value().y};
-                    const CBox grab = {real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA,
-                                       real.width + 2 * BORDER_GRAB_AREA, real.height + 2 * BORDER_GRAB_AREA};
+                    const CBox real = {
+                        w->m_realPosition->value().x, w->m_realPosition->value().y, w->m_realSize->value().x,
+                        w->m_realSize->value().y
+                    };
+                    const CBox grab = {
+                        real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA, real.width + 2 * BORDER_GRAB_AREA,
+                        real.height + 2 * BORDER_GRAB_AREA
+                    };
 
                     bool notInRealWindow = !real.containsPoint(touchPos) || w->isInCurvedCorner(touchPos.x, touchPos.y);
                     bool onTiledGap      = !w->m_isFloating && !w->isFullscreen() && notInRealWindow;
@@ -300,8 +309,10 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
     switch (this->getActiveDragGesture()->type) {
         case DragGestureType::SWIPE:
             if (this->hookHandled) {
-                EMIT_HOOK_EVENT("hyprgrass:swipeUpdate",
-                                pixelPositionToPercentagePosition(this->m_sGestureState.get_center().current))
+                EMIT_HOOK_EVENT(
+                    "hyprgrass:swipeUpdate",
+                    pixelPositionToPercentagePosition(this->m_sGestureState.get_center().current)
+                )
             } else if (this->workspaceSwipeActive) {
                 this->updateWorkspaceSwipe();
             } else if (**EMULATE_TOUCHPAD) {
@@ -309,7 +320,8 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
                 const auto delta                  = currentPoint - this->emulatedSwipePoint;
                 IPointer::SSwipeUpdateEvent swipe = {
                     .fingers = static_cast<uint32_t>(this->getActiveDragGesture()->finger_count),
-                    .delta   = Vector2D(delta.x, delta.y)};
+                    .delta   = Vector2D(delta.x, delta.y)
+                };
                 g_pInputManager->onSwipeUpdate(swipe);
                 this->emulatedSwipePoint = currentPoint;
             };
@@ -322,8 +334,10 @@ void GestureManager::dragGestureUpdate(const wf::touch::gesture_event_t& ev) {
         }
         case DragGestureType::EDGE_SWIPE:
             if (this->hookHandled) {
-                EMIT_HOOK_EVENT("hyprgrass:edgeUpdate",
-                                pixelPositionToPercentagePosition(this->m_sGestureState.get_center().current))
+                EMIT_HOOK_EVENT(
+                    "hyprgrass:edgeUpdate",
+                    pixelPositionToPercentagePosition(this->m_sGestureState.get_center().current)
+                )
 
                 return;
             }
@@ -358,8 +372,9 @@ void GestureManager::handleDragGestureEnd(const DragGestureEvent& gev) {
         case DragGestureType::LONG_PRESS:
             if (this->resizeOnBorderInfo.active) {
                 g_pKeybindManager->changeMouseBindMode(eMouseBindMode::MBIND_INVALID);
-                g_pConfigManager->parseKeyword("general:gaps_in",
-                                               commaSeparatedCssGaps(this->resizeOnBorderInfo.old_gaps_in));
+                g_pConfigManager->parseKeyword(
+                    "general:gaps_in", commaSeparatedCssGaps(this->resizeOnBorderInfo.old_gaps_in)
+                );
                 this->resizeOnBorderInfo = {};
                 return;
             }
@@ -399,8 +414,8 @@ bool GestureManager::handleWorkspaceSwipe(const GestureDirection direction) {
 }
 
 void GestureManager::updateWorkspaceSwipe() {
-    const auto  ANIMSTYLE = g_pUnifiedWorkspaceSwipe->m_workspaceBegin->m_renderOffset->getStyle();
-    const bool  VERTANIMS = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
+    const auto ANIMSTYLE = g_pUnifiedWorkspaceSwipe->m_workspaceBegin->m_renderOffset->getStyle();
+    const bool VERTANIMS = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
 
     static auto const PSWIPEDIST =
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "gestures:workspace_swipe_distance")

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -57,6 +57,7 @@ class GestureManager : public IGestureManager {
     } resizeOnBorderInfo;
     bool workspaceSwipeActive = false;
     bool hookHandled          = false;
+    // used by emulate_touchpad_swipe and trackpadGesture* functions
     wf::touch::point_t emulatedSwipePoint;
 
     bool handleGestureBind(std::string bind, GestureEventType);
@@ -66,8 +67,13 @@ class GestureManager : public IGestureManager {
     wf::touch::point_t wlrTouchEventPositionAsPixels(double x, double y) const;
     // reverse of wlrTouchEventPositionAsPixels
     Vector2D pixelPositionToPercentagePosition(wf::touch::point_t) const;
+    Vector2D pixelToTrackpadDistance(wf::touch::point_t) const;
     bool handleWorkspaceSwipe(const GestureDirection direction);
     void updateWorkspaceSwipe();
+
+    bool trackpadGestureBegin(const DragGestureEvent& gev);
+    void trackpadGestureUpdate(uint32_t time);
+    void trackpadGestureEnd(const DragGestureEvent& gev);
 
     bool handleDragGesture(const DragGestureEvent& gev) override;
     void dragGestureUpdate(const wf::touch::gesture_event_t&) override;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -6,6 +6,7 @@
 #include <hyprland/src/config/ConfigDataValues.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
+#include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
 #undef private
 
 enum class GestureEventType {
@@ -79,3 +80,4 @@ class GestureManager : public IGestureManager {
 };
 
 inline std::unique_ptr<GestureManager> g_pGestureManager;
+inline std::unique_ptr<CTrackpadGestures> g_pHyprgrassTrackpadGestures;

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -1,6 +1,6 @@
 #include "TouchVisualizer.hpp"
-#include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/Compositor.hpp>
+#include <hyprland/src/render/Renderer.hpp>
 
 CBox boxAroundCenter(Vector2D center, double radius) {
     return CBox(center.x - radius, center.y - radius, 2 * radius, 2 * radius);
@@ -26,8 +26,9 @@ Visualizer::Visualizer() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 2 * TOUCH_POINT_RADIUS, 2 * TOUCH_POINT_RADIUS, 0, GL_RGBA,
-                 GL_UNSIGNED_BYTE, data);
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, GL_RGBA, 2 * TOUCH_POINT_RADIUS, 2 * TOUCH_POINT_RADIUS, 0, GL_RGBA, GL_UNSIGNED_BYTE, data
+    );
 }
 
 Visualizer::~Visualizer() {
@@ -54,7 +55,7 @@ void Visualizer::onRender() {
 
     for (auto& finger : this->finger_positions) {
         CBox dmg = boxAroundCenter(finger.second.curr, TOUCH_POINT_RADIUS);
-        g_pHyprOpenGL->renderTexture(this->texture, dmg, { .a = 1.f, .round = 0, .discardActive = true });
+        g_pHyprOpenGL->renderTexture(this->texture, dmg, {.a = 1.f, .round = 0, .discardActive = true});
     }
 }
 

--- a/src/gestures/Actions.cpp
+++ b/src/gestures/Actions.cpp
@@ -1,8 +1,8 @@
 #include "Actions.hpp"
 #include <glm/glm.hpp>
 
-wf::touch::action_status_t CMultiAction::update_state(const wf::touch::gesture_state_t& state,
-                                                      const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+CMultiAction::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > *this->timeout) {
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
@@ -44,8 +44,8 @@ wf::touch::action_status_t CMultiAction::update_state(const wf::touch::gesture_s
     return wf::touch::ACTION_STATUS_RUNNING;
 }
 
-wf::touch::action_status_t MultiFingerDownAction::update_state(const wf::touch::gesture_state_t& state,
-                                                               const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+MultiFingerDownAction::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > this->get_duration()) {
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
@@ -61,8 +61,8 @@ wf::touch::action_status_t MultiFingerDownAction::update_state(const wf::touch::
     return wf::touch::ACTION_STATUS_RUNNING;
 }
 
-wf::touch::action_status_t MultiFingerTap::update_state(const wf::touch::gesture_state_t& state,
-                                                        const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+MultiFingerTap::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > *this->timeout) {
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
@@ -83,8 +83,8 @@ wf::touch::action_status_t MultiFingerTap::update_state(const wf::touch::gesture
     return wf::touch::ACTION_STATUS_RUNNING;
 }
 
-wf::touch::action_status_t LongPress::update_state(const wf::touch::gesture_state_t& state,
-                                                   const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+LongPress::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > *this->delay) {
         return wf::touch::ACTION_STATUS_COMPLETED;
     }
@@ -112,8 +112,8 @@ wf::touch::action_status_t LongPress::update_state(const wf::touch::gesture_stat
     return wf::touch::ACTION_STATUS_RUNNING;
 }
 
-wf::touch::action_status_t LiftoffAction::update_state(const wf::touch::gesture_state_t& state,
-                                                       const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+LiftoffAction::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > this->get_duration()) {
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
@@ -129,8 +129,8 @@ wf::touch::action_status_t LiftoffAction::update_state(const wf::touch::gesture_
     return wf::touch::ACTION_STATUS_RUNNING;
 }
 
-wf::touch::action_status_t TouchUpOrDownAction::update_state(const wf::touch::gesture_state_t& state,
-                                                             const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+TouchUpOrDownAction::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > this->get_duration()) {
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
@@ -142,8 +142,8 @@ wf::touch::action_status_t TouchUpOrDownAction::update_state(const wf::touch::ge
     return wf::touch::ACTION_STATUS_RUNNING;
 }
 
-wf::touch::action_status_t LiftAll::update_state(const wf::touch::gesture_state_t& state,
-                                                 const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+LiftAll::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     if (event.time - this->start_time > this->get_duration()) {
         return wf::touch::ACTION_STATUS_CANCELLED;
     }
@@ -154,12 +154,12 @@ wf::touch::action_status_t LiftAll::update_state(const wf::touch::gesture_state_
 
     return wf::touch::ACTION_STATUS_RUNNING;
 }
-wf::touch::action_status_t OnCompleteAction::update_state(const wf::touch::gesture_state_t& state,
-                                                          const wf::touch::gesture_event_t& event) {
+wf::touch::action_status_t
+OnCompleteAction::update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) {
     auto status = this->action->update_state(state, event);
 
     if (status == wf::touch::ACTION_STATUS_COMPLETED) {
-        this->callback();
+        this->callback(event.time);
     }
 
     return status;

--- a/src/gestures/Actions.hpp
+++ b/src/gestures/Actions.hpp
@@ -17,7 +17,7 @@ class CMultiAction : public wf::touch::gesture_action_t {
     // if the threshold needs to be adjusted dynamically, the sensitivity
     // pointer is used
     CMultiAction(double base_threshold, const float* sensitivity, const int64_t* timeout)
-        : base_threshold(base_threshold), sensitivity(sensitivity), timeout(timeout){};
+        : base_threshold(base_threshold), sensitivity(sensitivity), timeout(timeout) {};
 
     GestureDirection target_direction = 0;
     int finger_count                  = 0;
@@ -27,8 +27,8 @@ class CMultiAction : public wf::touch::gesture_action_t {
     // This action should be followed by another that completes upon lifting a
     // finger to achieve a gesture that completes after a multi-finger swipe is
     // done and lifted.
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 
     void reset(uint32_t time) override {
         gesture_action_t::reset(time);
@@ -44,10 +44,10 @@ class MultiFingerTap : public wf::touch::gesture_action_t {
 
   public:
     MultiFingerTap(double base_threshold, const float* sensitivity, const int64_t* timeout)
-        : base_threshold(base_threshold), sensitivity(sensitivity), timeout(timeout){};
+        : base_threshold(base_threshold), sensitivity(sensitivity), timeout(timeout) {};
 
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 };
 
 class LongPress : public wf::touch::gesture_action_t {
@@ -59,13 +59,15 @@ class LongPress : public wf::touch::gesture_action_t {
 
   public:
     // TODO: I hope one day I can figure out how not to pass a function for the update timer callback
-    LongPress(double base_threshold, const float* sensitivity, const int64_t* delay,
-              UpdateExternalTimerCallback update_external_timer)
+    LongPress(
+        double base_threshold, const float* sensitivity, const int64_t* delay,
+        UpdateExternalTimerCallback update_external_timer
+    )
         : base_threshold(base_threshold), sensitivity(sensitivity), delay(delay),
-          update_external_timer_callback(update_external_timer){};
+          update_external_timer_callback(update_external_timer) {};
 
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 };
 
 // Completes upon receiving enough touch down events within a short duration
@@ -77,43 +79,44 @@ class MultiFingerDownAction : public wf::touch::gesture_action_t {
   public:
     MultiFingerDownAction() {}
 
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 };
 
 // Completes upon receiving a touch up event and cancels upon receiving a touch
 // down event.
 class LiftoffAction : public wf::touch::gesture_action_t {
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 };
 
 // Completes upon receiving a touch up or touch down event
 class TouchUpOrDownAction : public wf::touch::gesture_action_t {
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 };
 
 // Completes upon all touch points lifted.
 class LiftAll : public wf::touch::gesture_action_t {
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 };
 
 // This action is used to call a function right after another action is completed
 class OnCompleteAction : public wf::touch::gesture_action_t {
+    using Callback = std::function<void(uint32_t)>;
+
   private:
     std::unique_ptr<wf::touch::gesture_action_t> action;
-    const std::function<void()> callback;
+    const Callback callback;
 
   public:
-    OnCompleteAction(std::unique_ptr<wf::touch::gesture_action_t> action, std::function<void()> callback)
-        : callback(callback) {
+    OnCompleteAction(std::unique_ptr<wf::touch::gesture_action_t> action, Callback callback) : callback(callback) {
         this->action = std::move(action);
     }
 
-    wf::touch::action_status_t update_state(const wf::touch::gesture_state_t& state,
-                                            const wf::touch::gesture_event_t& event) override;
+    wf::touch::action_status_t
+    update_state(const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t& event) override;
 
     void reset(uint32_t time) override {
         this->action->reset(time);

--- a/src/gestures/DragGesture.hpp
+++ b/src/gestures/DragGesture.hpp
@@ -8,6 +8,7 @@ enum class DragGestureType {
 };
 
 struct DragGestureEvent {
+    uint32_t time;
     DragGestureType type;
     GestureDirection direction;
     int finger_count;

--- a/src/gestures/Gestures.cpp
+++ b/src/gestures/Gestures.cpp
@@ -1,5 +1,6 @@
 #include "Gestures.hpp"
 #include "Actions.hpp"
+#include "DragGesture.hpp"
 #include <glm/glm.hpp>
 #include <memory>
 #include <optional>
@@ -134,39 +135,50 @@ void IGestureManager::addMultiFingerGesture(const float* sensitivity, const int6
 
     auto swipe_ptr = swipe.get();
 
-    auto swipe_and_emit = std::make_unique<OnCompleteAction>(std::move(swipe), [=, this]() {
+    auto swipe_and_emit = std::make_unique<OnCompleteAction>(std::move(swipe), [=, this](uint32_t time) {
         if (this->activeDragGesture.has_value()) {
             return;
         }
-        const auto gesture = DragGestureEvent{DragGestureType::SWIPE, swipe_ptr->target_direction,
-                                              static_cast<int>(this->m_sGestureState.fingers.size())};
+
+        const auto gesture = DragGestureEvent{
+            .time         = time,
+            .type         = DragGestureType::SWIPE,
+            .direction    = swipe_ptr->target_direction,
+            .finger_count = static_cast<int>(this->m_sGestureState.fingers.size())
+        };
 
         if (this->emitDragGesture(gesture)) {
             this->cancelTouchEventsOnAllWindows();
         }
     });
 
-    auto swipe_liftoff = std::make_unique<LiftoffAction>();
-
-    std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
-    swipe_actions.emplace_back(std::move(swipe_and_emit));
-    swipe_actions.emplace_back(std::move(swipe_liftoff));
-
-    auto ack = [swipe_ptr, this]() {
-        const auto drag =
-            DragGestureEvent{DragGestureType::SWIPE, 0, static_cast<int>(this->m_sGestureState.fingers.size())};
+    auto swipe_liftoff   = std::make_unique<LiftoffAction>();
+    auto liftoff_and_ack = std::make_unique<OnCompleteAction>(std::move(swipe_liftoff), [=, this](uint32_t time) {
+        const auto drag = DragGestureEvent{
+            .time         = time,
+            .type         = DragGestureType::SWIPE,
+            .direction    = 0,
+            .finger_count = static_cast<int>(this->m_sGestureState.fingers.size())
+        };
         if (this->emitDragGestureEnd(drag)) {
             return;
         } else {
-            const auto gesture = CompletedGestureEvent{CompletedGestureType::SWIPE, swipe_ptr->target_direction,
-                                                       static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture = CompletedGestureEvent{
+                CompletedGestureType::SWIPE, swipe_ptr->target_direction,
+                static_cast<int>(this->m_sGestureState.fingers.size())
+            };
 
             this->emitCompletedGesture(gesture);
         }
-    };
+    });
+
+    std::vector<std::unique_ptr<wf::touch::gesture_action_t>> swipe_actions;
+    swipe_actions.emplace_back(std::move(swipe_and_emit));
+    swipe_actions.emplace_back(std::move(liftoff_and_ack));
+
     auto cancel = [this]() { this->handleCancelledGesture(); };
 
-    this->addTouchGesture(std::make_unique<wf::touch::gesture_t>(std::move(swipe_actions), ack, cancel));
+    this->addTouchGesture(std::make_unique<wf::touch::gesture_t>(std::move(swipe_actions), []() {}, cancel));
 }
 
 void IGestureManager::addMultiFingerTap(const float* sensitivity, const int64_t* timeout) {
@@ -191,62 +203,103 @@ void IGestureManager::addLongPress(const float* sensitivity, const int64_t* dela
     auto long_press_and_emit = std::make_unique<OnCompleteAction>(
         std::make_unique<LongPress>(
             SWIPE_INCORRECT_DRAG_TOLERANCE, sensitivity, delay,
-            [this](uint32_t current_time, uint32_t delay) { this->updateLongPressTimer(current_time, delay); }),
-        [this]() {
+            [this](uint32_t current_time, uint32_t delay) { this->updateLongPressTimer(current_time, delay); }
+        ),
+        [this](uint32_t time) {
             if (this->activeDragGesture.has_value()) {
                 return;
             }
-            const auto gesture = DragGestureEvent{DragGestureType::LONG_PRESS, 0,
-                                                  static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture = DragGestureEvent{
+                .time         = time,
+                .type         = DragGestureType::LONG_PRESS,
+                .direction    = 0,
+                .finger_count = static_cast<int>(this->m_sGestureState.fingers.size())
+            };
 
-            const auto gesture1 = CompletedGestureEvent{CompletedGestureType::LONG_PRESS, 0,
-                                                        static_cast<int>(this->m_sGestureState.fingers.size())};
+            const auto gesture1 = CompletedGestureEvent{
+                CompletedGestureType::LONG_PRESS, 0, static_cast<int>(this->m_sGestureState.fingers.size())
+            };
 
             bool handled = this->emitDragGesture(gesture) || this->emitCompletedGesture(gesture1);
 
             if (handled) {
                 this->cancelTouchEventsOnAllWindows();
             }
-        });
+        }
+    );
 
-    auto lift_all = std::make_unique<LiftAll>();
+    auto lift_all_and_ack = std::make_unique<OnCompleteAction>(std::make_unique<LiftAll>(), [this](uint32_t time) {
+        if (this->activeDragGesture.has_value()) {
+            DragGestureEvent gev = {this->activeDragGesture.value()};
+            gev.time             = time;
+            this->emitDragGestureEnd(gev);
+            return;
+        };
+    });
 
     std::vector<std::unique_ptr<wf::touch::gesture_action_t>> long_press_actions;
     long_press_actions.emplace_back(std::move(long_press_and_emit));
-    long_press_actions.emplace_back(std::move(lift_all));
+    long_press_actions.emplace_back(std::move(lift_all_and_ack));
 
-    auto ack = [this]() {
-        if (this->activeDragGesture.has_value()) {
-            this->emitDragGestureEnd(this->activeDragGesture.value());
-            return;
-        };
-    };
     auto cancel = [this]() {
         this->stopLongPressTimer();
         this->handleCancelledGesture();
     };
 
-    this->addTouchGesture(std::make_unique<wf::touch::gesture_t>(std::move(long_press_actions), ack, cancel));
+    this->addTouchGesture(std::make_unique<wf::touch::gesture_t>(std::move(long_press_actions), []() {}, cancel));
 }
 
-void IGestureManager::addEdgeSwipeGesture(const float* sensitivity, const int64_t* timeout,
-                                          const long int* edge_margin) {
+void IGestureManager::addEdgeSwipeGesture(
+    const float* sensitivity, const int64_t* timeout, const long int* edge_margin
+) {
     auto edge            = std::make_unique<CMultiAction>(SWIPE_INCORRECT_DRAG_TOLERANCE, sensitivity, timeout);
     auto edge_ptr        = edge.get();
-    auto edge_drag_begin = std::make_unique<OnCompleteAction>(std::move(edge), [=, this]() {
+    auto edge_drag_begin = std::make_unique<OnCompleteAction>(std::move(edge), [=, this](uint32_t time) {
         auto origin_edges = this->find_swipe_edges(m_sGestureState.get_center().origin, *edge_margin);
 
         if (origin_edges == 0) {
             return;
         }
         auto direction = edge_ptr->target_direction;
-        auto gesture   = DragGestureEvent{DragGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges};
+        auto gesture   = DragGestureEvent{
+              .time         = time,
+              .type         = DragGestureType::EDGE_SWIPE,
+              .direction    = direction,
+              .finger_count = edge_ptr->finger_count,
+              .edge_origin  = origin_edges
+        };
         if (this->emitDragGesture(gesture)) {
             this->cancelTouchEventsOnAllWindows();
         }
     });
-    auto edge_release    = std::make_unique<wf::touch::touch_action_t>(1, false);
+    auto release_and_ack = std::make_unique<OnCompleteAction>(
+        std::make_unique<wf::touch::touch_action_t>(1, false),
+        [edge_ptr, edge_margin, this](uint32_t time) {
+            auto origin_edges = find_swipe_edges(m_sGestureState.get_center().origin, *edge_margin);
+            auto direction    = edge_ptr->target_direction;
+            auto dragEvent    = DragGestureEvent{
+                   .time         = time,
+                   .type         = DragGestureType::EDGE_SWIPE,
+                   .direction    = direction,
+                   .finger_count = edge_ptr->finger_count,
+                   .edge_origin  = origin_edges,
+            };
 
+            if (this->emitDragGestureEnd(dragEvent)) {
+                return;
+            }
+
+            if (origin_edges == 0) {
+                return;
+            }
+
+            auto event = CompletedGestureEvent{
+                CompletedGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges
+            };
+
+            this->emitCompletedGesture(event);
+        }
+    );
     // TODO do I really need this:
     // edge->set_move_tolerance(SWIPE_INCORRECT_DRAG_TOLERANCE * *sensitivity);
 
@@ -257,33 +310,10 @@ void IGestureManager::addEdgeSwipeGesture(const float* sensitivity, const int64_
 
     std::vector<std::unique_ptr<wf::touch::gesture_action_t>> edge_swipe_actions;
     edge_swipe_actions.emplace_back(std::move(edge_drag_begin));
-    edge_swipe_actions.emplace_back(std::move(edge_release));
+    edge_swipe_actions.emplace_back(std::move(release_and_ack));
 
-    auto ack = [edge_ptr, edge_margin, this]() {
-        auto origin_edges = find_swipe_edges(m_sGestureState.get_center().origin, *edge_margin);
-        auto direction    = edge_ptr->target_direction;
-        auto dragEvent    = DragGestureEvent{
-               .type         = DragGestureType::EDGE_SWIPE,
-               .direction    = direction,
-               .finger_count = edge_ptr->finger_count,
-               .edge_origin  = origin_edges,
-        };
-
-        if (this->emitDragGestureEnd(dragEvent)) {
-            return;
-        }
-
-        if (origin_edges == 0) {
-            return;
-        }
-
-        auto event =
-            CompletedGestureEvent{CompletedGestureType::EDGE_SWIPE, direction, edge_ptr->finger_count, origin_edges};
-
-        this->emitCompletedGesture(event);
-    };
     auto cancel = [this]() { this->handleCancelledGesture(); };
 
-    auto gesture = std::make_unique<wf::touch::gesture_t>(std::move(edge_swipe_actions), ack, cancel);
+    auto gesture = std::make_unique<wf::touch::gesture_t>(std::move(edge_swipe_actions), []() {}, cancel);
     this->addTouchGesture(std::move(gesture));
 }

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -75,8 +75,9 @@ void ProcessEvent(CMockGestureManager& gm, const wf::touch::gesture_event_t& ev)
     }
 }
 
-void ProcessEvents(CMockGestureManager& gm, ExpectResult expect,
-                   const std::vector<wf::touch::gesture_event_t>& events) {
+void ProcessEvents(
+    CMockGestureManager& gm, ExpectResult expect, const std::vector<wf::touch::gesture_event_t>& events
+) {
     for (const auto& ev : events) {
         ProcessEvent(gm, ev);
     }
@@ -111,11 +112,13 @@ void ProcessEvents(CMockGestureManager& gm, ExpectResult expect,
 using TouchEvent = wf::touch::gesture_event_t;
 using wf::touch::point_t;
 
-TEST_CASE("Multifinger: block touch events to client surfaces when more than a "
-          "certain number of fingers touch down." *
-          // multi-finger used to cancel touch events on 3 finger touch down
-          // currently removed but may bring it back
-          doctest::should_fail()) {
+TEST_CASE(
+    "Multifinger: block touch events to client surfaces when more than a "
+    "certain number of fingers touch down." *
+    // multi-finger used to cancel touch events on 3 finger touch down
+    // currently removed but may bring it back
+    doctest::should_fail()
+) {
     std::cout << "  ==== stdout:" << std::endl;
     auto gm = CMockGestureManager::newCompletedGestureOnlyHandler();
     gm.addMultiFingerGesture(&SENSITIVITY, &LONG_PRESS_DELAY);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,8 +223,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::reloadConfig();
 
-    g_pGestureManager = std::make_unique<GestureManager>();
-    g_pVisualizer     = std::make_unique<Visualizer>();
+    g_pGestureManager            = std::make_unique<GestureManager>();
+    g_pHyprgrassTrackpadGestures = std::make_unique<CTrackpadGestures>();
+    g_pVisualizer                = std::make_unique<Visualizer>();
 
     return {"hyprgrass", "Touchscreen gestures", "horriblename", HYPRGRASS_VERSION};
 }


### PR DESCRIPTION
introduces a `hyprgrass-gesture` keyword which binds hyprgrass gestures to HL builtin trackpad
gesture actions. I was hoping this would be extensible in the same way as dispatchers, but
unfortunately not, plugins do not register their ITrackpadGesture in a central location, so we
cannot use this to replace our event hooks API :c
