### PR TITLE
Updated hash checking

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -358,8 +358,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprgrass:debug:binds", listInternalBinds);
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprgrass:debug:hooks", listHooks);
 
-    const auto hlTargetVersion = __hyprland_api_get_hash();
-    const auto hlVersion       = __hyprland_api_get_client_hash();
+    const std::string hlTargetVersion = __hyprland_api_get_hash();
+    const std::string hlVersion       = __hyprland_api_get_client_hash();
 
     if (hlVersion != hlTargetVersion) {
         HyprlandAPI::addNotification(


### PR DESCRIPTION
This is needed since hyprwm/Hyprland#12110 got merged.
More work is needed tho.
This appears to be working perfectly fine on all the other plugins I updated so far, however, I am somehow getting mismatched headers here.
I am not sure whether there's something else I am missing, but either way, this is how the patch should look like for all plugins.
<img width="1178" height="202" alt="image" src="https://github.com/user-attachments/assets/6f2da70f-b81e-490c-8d1b-12a975fb26a9" />
