### PR TITLE
chore: pin 0.53.3

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -48,6 +48,7 @@ commit_pins = [
     ["ea444c35bb23b6e34505ab6753e069de7801cc25", "569e28f30b5e68ddb0da65248259b8fe2c1ff9a0"], # v0.53.0
     ["f8464866ebacb8d17b37bab77c4ff9b1c1a34371", "b09a8450ea8207ab5cb3e2ea075390b95534cd2b"], # gesture inhibit
     ["ab1d80f3d6aebd57a0971b53a1993b1c1dfe0b09", "569e28f30b5e68ddb0da65248259b8fe2c1ff9a0"], # v0.53.1
+    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "569e28f30b5e68ddb0da65248259b8fe2c1ff9a0"], # v0.53.3
     ## DO NOT EDIT THIS LINE: for auto pin script ##
 ]
 


### PR DESCRIPTION
Untested pin

nix seems to fail to build hyprland 0.53.3, so I just added the same pin to
0.53.1 for 0.53.3. Hope nothing breaks (ping me if it does)

gonna skip making the hl-0.53.3 pin cuz the tags were mainly for nix users and
that version of hl doesn't even build
