### PR TITLE
fix: disable tests on wf-touch if doctest >= 2.5.0

### DIFF
--- a/nix/wf-touch.nix
+++ b/nix/wf-touch.nix
@@ -8,32 +8,39 @@
   ninja,
   glm,
   doctest,
-}:
-stdenv.mkDerivation {
-  pname = "wf-touch";
-  version = "git";
-  src = fetchFromGitHub {
-    owner = "WayfireWM";
-    repo = "wf-touch";
-    rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
-    hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
-  };
+}: let
+  inherit (lib) compareVersions optionals;
 
-  nativeBuildInputs = [meson pkg-config cmake ninja];
-  buildInputs = [doctest];
-  propagatedBuildInputs = [glm];
+  supportedDoctest = (compareVersions doctest.version "2.5.0") == -1;
+in
+  stdenv.mkDerivation {
+    pname = "wf-touch";
+    version = "git";
+    src = fetchFromGitHub {
+      owner = "WayfireWM";
+      repo = "wf-touch";
+      rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
+      hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
+    };
 
-  mesonBuildType = "release";
+    nativeBuildInputs = [meson pkg-config cmake ninja] ++ optionals supportedDoctest [doctest];
+    propagatedBuildInputs = [glm];
 
-  patches = [
-    ./wf-touch.patch
-  ];
+    mesonBuildType = "release";
 
-  outputs = ["out" "dev"];
-  meta = with lib; {
-    homepage = "https://github.com/WayfireWM/wf-touch";
-    license = licenses.mit;
-    description = "Touchscreen gesture library";
-    platforms = platforms.all;
-  };
-}
+    mesonFlags = optionals (!supportedDoctest) [
+      "-Dtests=disabled"
+    ];
+
+    patches = [
+      ./wf-touch.patch
+    ];
+
+    outputs = ["out" "dev"];
+    meta = with lib; {
+      homepage = "https://github.com/WayfireWM/wf-touch";
+      license = licenses.mit;
+      description = "Touchscreen gesture library";
+      platforms = platforms.all;
+    };
+  }


### PR DESCRIPTION
Latest Nixpkgs unstable updated doctest to 2.5.0 and it makes wf-touch build fail

I only disabled tests if the version is >=2.5.0