### PR TITLE
Revert "fix: disable tests on wf-touch if doctest >= 2.5.0"

### DIFF
--- a/nix/wf-touch.nix
+++ b/nix/wf-touch.nix
@@ -8,39 +8,32 @@
   ninja,
   glm,
   doctest,
-}: let
-  inherit (lib) compareVersions optionals;
+}:
+stdenv.mkDerivation {
+  pname = "wf-touch";
+  version = "git";
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wf-touch";
+    rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
+    hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
+  };
 
-  supportedDoctest = (compareVersions doctest.version "2.5.0") == -1;
-in
-  stdenv.mkDerivation {
-    pname = "wf-touch";
-    version = "git";
-    src = fetchFromGitHub {
-      owner = "WayfireWM";
-      repo = "wf-touch";
-      rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
-      hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
-    };
+  nativeBuildInputs = [meson pkg-config cmake ninja];
+  buildInputs = [doctest];
+  propagatedBuildInputs = [glm];
 
-    nativeBuildInputs = [meson pkg-config cmake ninja] ++ optionals supportedDoctest [doctest];
-    propagatedBuildInputs = [glm];
+  mesonBuildType = "release";
 
-    mesonBuildType = "release";
+  patches = [
+    ./wf-touch.patch
+  ];
 
-    mesonFlags = optionals (!supportedDoctest) [
-      "-Dtests=disabled"
-    ];
-
-    patches = [
-      ./wf-touch.patch
-    ];
-
-    outputs = ["out" "dev"];
-    meta = with lib; {
-      homepage = "https://github.com/WayfireWM/wf-touch";
-      license = licenses.mit;
-      description = "Touchscreen gesture library";
-      platforms = platforms.all;
-    };
-  }
+  outputs = ["out" "dev"];
+  meta = with lib; {
+    homepage = "https://github.com/WayfireWM/wf-touch";
+    license = licenses.mit;
+    description = "Touchscreen gesture library";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This reverts commit 37e973b1db14ccbbbfce050939c13fccaed20f35.

Turns out this was a doctest bug fixed in 2.5.1: https://github.com/doctest/doctest/issues/1098

Since we don't even use the nixpkgs version with 2.5.0 i'll just revert my changes and do an overlay in my personal config

Sorry for the useless commits lol