### PR TITLE
fix: adapt to latest Hyprland config API changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772460678,
-        "narHash": "sha256-NYaWs8fYJ38IgFld0hGSdT2LEVhrgO8SiRReBjIH7YY=",
+        "lastModified": 1776876344,
+        "narHash": "sha256-Ubqb/agkuMJK+k19gjQgHux/eOYRc1sRGoOZOho8+VY=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "5d2cb726b16ee349df443f84b64cff53221b6983",
+        "rev": "648a13d0ee1e03a843b3e145b8ece15393058701",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772461003,
-        "narHash": "sha256-pVICsV7FtcEeVwg5y/LFh3XFUkVJninm/P1j/JHzEbM=",
+        "lastModified": 1776511930,
+        "narHash": "sha256-fCpwFiTW0rT7oKJqr3cqHMnkwypSwQKpbtUEtxdkgrM=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "b62396457b9cfe2ebf24fe05404b09d2a40f8ed7",
+        "rev": "39435900785d0c560c6ae8777d29f28617d031ef",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772461523,
-        "narHash": "sha256-mI6A51do+hEUzeJKk9YSWfVHdI/SEEIBi2tp5Whq5mI=",
+        "lastModified": 1776426399,
+        "narHash": "sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "7d63c04b4a2dd5e59ef943b4b143f46e713df804",
+        "rev": "68d064434787cf1ed4a2fe257c03c5f52f33cf84",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1774635470,
-        "narHash": "sha256-dYVtjeSZgQzNNDmeSwBnp7gH/zOLsI2YTlv7hagY6gs=",
+        "lastModified": 1777413378,
+        "narHash": "sha256-3ZAOkmOly7h3i22XNKHD9LEhFRTop3JT88PrlDaqnzo=",
         "owner": "hyprwm",
-        "repo": "hyprland",
-        "rev": "521ece463c4a9d3d128670688a34756805a4328f",
+        "repo": "Hyprland",
+        "rev": "e61976233e01446c4e7dd4fa3b4209fea1fca9ed",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772467975,
-        "narHash": "sha256-kipyuDBxrZq+beYpZqWzGvFWm4QbayW9agAvi94vDXY=",
+        "lastModified": 1776426575,
+        "narHash": "sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "5e1c6b9025aaf4d578f3eff7c0eb1f0c197a9507",
+        "rev": "a968d211048e3ed538e47b84cb3649299578f19d",
         "type": "github"
       },
       "original": {
@@ -246,11 +246,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772459629,
-        "narHash": "sha256-/iwvNUYShmmnwmz/czEUh6+0eF5vCMv0xtDW0STPIuM=",
+        "lastModified": 1776426736,
+        "narHash": "sha256-rl7i4aY+9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "7615ee388de18239a4ab1400946f3d0e498a8186",
+        "rev": "7833ff33b2e82d3406337b5dcf0d1cec595d83e9",
         "type": "github"
       },
       "original": {
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772459870,
-        "narHash": "sha256-xxkK2Cvqxpf/4UGcJ/TyCwrvmiNWsKsJfFzHMp2bxis=",
+        "lastModified": 1777148223,
+        "narHash": "sha256-PTf7kRFFzCW6rIYxLH2fWfVJmj86FSYe3k6L8B+IM9o=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e63f3a79334dec49f8eb1691f66f18115df04085",
+        "rev": "fa3992be2dfebe4ab06d753c6ca59bea298e798f",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772459835,
-        "narHash": "sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy+8X2lFZsak=",
+        "lastModified": 1777148232,
+        "narHash": "sha256-Uv0WZLhu89SafuSOmYDA7akrPt4wBRmsa1ucasO5aXg=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "0a692d4a645165eebd65f109146b8861e3a925e7",
+        "rev": "fec9cf1abcc1011e46f0a0986f46bf93c6bf8b92",
         "type": "github"
       },
       "original": {
@@ -377,11 +377,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772463520,
-        "narHash": "sha256-GIjASzYnV4fK19HnyJKmHyqyxHxIpjusK9foEA4Yo+4=",
+        "lastModified": 1776728575,
+        "narHash": "sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU=",
         "owner": "hyprwm",
         "repo": "hyprwire",
-        "rev": "4e1933ae5602b350c5b6633f5c932549c9b8aca2",
+        "rev": "f3a80888783702a39691b684d099e16b83ed4702",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772024342,
-        "narHash": "sha256-+eXlIc4/7dE6EcPs9a2DaSY3fTA9AE526hGqkNID3Wg=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6e34e97ed9788b17796ee43ccdbaf871a5c2b476",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772476586,
-        "narHash": "sha256-N/ZwsRLULLpBP5ecvAUzNq8E/CgLRwPwSrHyY3xB5KM=",
+        "lastModified": 1777035886,
+        "narHash": "sha256-m1TNuBoSXUBSKhD9UVMkU90M0wFTPTfvIOOltO8IM8A=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "eb6c02a2ead882f3474f3d7f2fbe966b64ed5110",
+        "rev": "ecfcdcc781f48821d83e1e2a0e30d7beca0eeb5e",
         "type": "github"
       },
       "original": {

--- a/nix/wf-touch.nix
+++ b/nix/wf-touch.nix
@@ -7,7 +7,6 @@
   cmake,
   ninja,
   glm,
-  doctest,
 }:
 stdenv.mkDerivation {
   pname = "wf-touch";
@@ -20,10 +19,14 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [meson pkg-config cmake ninja];
-  buildInputs = [doctest];
+  buildInputs = [ ];
   propagatedBuildInputs = [glm];
 
   mesonBuildType = "release";
+
+  mesonFlags = [
+    "-Dtests=disabled"
+  ];
 
   patches = [
     ./wf-touch.patch

--- a/nix/wf-touch.nix
+++ b/nix/wf-touch.nix
@@ -19,11 +19,12 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [meson pkg-config cmake ninja];
-  buildInputs = [ ];
+  buildInputs = [];
   propagatedBuildInputs = [glm];
 
   mesonBuildType = "release";
 
+  # TODO: doctest is currently broken: https://github.com/NixOS/nixpkgs/issues/514722
   mesonFlags = [
     "-Dtests=disabled"
   ];

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -5,8 +5,10 @@
 #define private public
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/legacy/ConfigManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
+#include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/managers/SeatManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/input/UnifiedWorkspaceSwipeGesture.hpp>
@@ -213,7 +215,7 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
                         newGapsIn.m_right += RESIZE_BORDER_GAP_INCREMENT;
                         newGapsIn.m_bottom += RESIZE_BORDER_GAP_INCREMENT;
                         newGapsIn.m_left += RESIZE_BORDER_GAP_INCREMENT;
-                        g_pConfigManager->parseKeyword("general:gaps_in", commaSeparatedCssGaps(newGapsIn));
+                        Config::Legacy::mgr()->parseKeyword("general:gaps_in", commaSeparatedCssGaps(newGapsIn));
                         return true;
                     }
                 }
@@ -381,7 +383,7 @@ void GestureManager::handleDragGestureEnd(const DragGestureEvent& gev) {
         case DragGestureType::LONG_PRESS:
             if (this->resizeOnBorderInfo.active) {
                 g_pKeybindManager->changeMouseBindMode(eMouseBindMode::MBIND_INVALID);
-                g_pConfigManager->parseKeyword(
+                Config::Legacy::mgr()->parseKeyword(
                     "general:gaps_in", commaSeparatedCssGaps(this->resizeOnBorderInfo.old_gaps_in)
                 );
                 this->resizeOnBorderInfo = {};
@@ -586,9 +588,9 @@ bool GestureManager::onTouchDown(ITouch::SDownEvent ev) {
 
     const auto& monitorPos  = this->m_lastTouchedMonitor->m_position;
     const auto& monitorSize = this->m_lastTouchedMonitor->m_size;
-    this->m_monitorArea     = {monitorPos.x, monitorPos.y, monitorSize.x, monitorSize.y};
+    this->m_monitorArea     = SMonitorArea{monitorPos.x, monitorPos.y, monitorSize.x, monitorSize.y};
 
-    g_pCompositor->warpCursorTo({
+    g_pCompositor->warpCursorTo(Vector2D{
         monitorPos.x + ev.pos.x * monitorSize.x,
         monitorPos.y + ev.pos.y * monitorSize.y,
     });

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -61,7 +61,7 @@ int handleLongPressTimer(void* data) {
     return 0;
 }
 
-std::string commaSeparatedCssGaps(CCssGapData data) {
+std::string commaSeparatedCssGaps(Config::CCssGapData data) {
     return std::to_string(data.m_top) + "," + std::to_string(data.m_right) + "," + std::to_string(data.m_bottom) + "," +
            std::to_string(data.m_left);
 }
@@ -202,13 +202,13 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
                         };
                         g_pKeybindManager->resizeWithBorder(e);
 
-                        auto* PGAPSIN            = static_cast<CCssGapData*>(PGAPSINDATA.ptr());
+                        auto* PGAPSIN            = static_cast<Config::CCssGapData*>(PGAPSINDATA.ptr());
                         this->resizeOnBorderInfo = {
                             .active      = true,
                             .old_gaps_in = *PGAPSIN,
                         };
 
-                        CCssGapData newGapsIn = *PGAPSIN;
+                        Config::CCssGapData newGapsIn = *PGAPSIN;
                         newGapsIn.m_top += RESIZE_BORDER_GAP_INCREMENT;
                         newGapsIn.m_right += RESIZE_BORDER_GAP_INCREMENT;
                         newGapsIn.m_bottom += RESIZE_BORDER_GAP_INCREMENT;

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -119,7 +119,7 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
     static auto PBORDERGRABEXTEND =
         (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "general:extend_border_grab_area")
             ->getDataStaticPtr();
-    static auto PGAPSINDATA = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_in");
+    static auto PGAPSINDATA = CConfigValue<Config::IComplexConfigValue>("general:gaps_in");
 
     Log::logger->log(Log::DEBUG, "[hyprgrass] Drag gesture begin: {}", gev.to_string());
 
@@ -202,7 +202,7 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
                         };
                         g_pKeybindManager->resizeWithBorder(e);
 
-                        auto* PGAPSIN            = (CCssGapData*)(PGAPSINDATA.ptr())->getData();
+                        auto* PGAPSIN            = static_cast<CCssGapData*>(PGAPSINDATA.ptr());
                         this->resizeOnBorderInfo = {
                             .active      = true,
                             .old_gaps_in = *PGAPSIN,

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -3,6 +3,8 @@
 #include "ShimTrackpadGestures.hpp"
 #include "VecSet.hpp"
 
+#include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
+
 #define private public
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
@@ -55,7 +57,7 @@ class GestureManager : public IGestureManager {
     wl_event_source* long_press_timer;
     struct {
         bool active = false;
-        CCssGapData old_gaps_in;
+        Config::CCssGapData old_gaps_in;
     } resizeOnBorderInfo;
     bool workspaceSwipeActive                = false;
     CTrackpadGestures* activeTrackpadGesture = nullptr;

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -4,7 +4,7 @@
 #include "VecSet.hpp"
 
 #define private public
-#include <hyprland/src/config/ConfigDataValues.hpp>
+#include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>

--- a/src/ShimTrackpadGestures.cpp
+++ b/src/ShimTrackpadGestures.cpp
@@ -37,7 +37,7 @@ bool ShimTrackpadGestures::isPinch(eTrackpadGestureDirection dir) {
     }
 }
 
-std::expected<GestureConfig, std::string> parseGesturePattern(CConstVarList& vars) {
+std::expected<GestureConfig, std::string> parseGesturePattern(Hyprutils::String::CConstVarList& vars) {
     DragGestureType type;
     size_t fingersOrOrigin              = 0;
     eTrackpadGestureDirection direction = TRACKPAD_GESTURE_DIR_NONE;

--- a/src/ShimTrackpadGestures.hpp
+++ b/src/ShimTrackpadGestures.hpp
@@ -1,5 +1,6 @@
 #include "gestures/DragGesture.hpp"
 #include "src/managers/input/trackpad/GestureTypes.hpp"
+#include <any>
 #include <string>
 
 #include <hyprland/src/config/ConfigManager.hpp>

--- a/src/ShimTrackpadGestures.hpp
+++ b/src/ShimTrackpadGestures.hpp
@@ -4,6 +4,7 @@
 
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprutils/string/ConstVarList.hpp>
+#include <hyprutils/string/VarList.hpp>
 
 #define private public
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
@@ -15,7 +16,7 @@ struct GestureConfig {
     size_t fingers;
 };
 
-std::expected<GestureConfig, std::string> parseGesturePattern(CConstVarList& vars);
+std::expected<GestureConfig, std::string> parseGesturePattern(Hyprutils::String::CConstVarList& vars);
 GestureDirection toHyprgrassDirection(eTrackpadGestureDirection dir);
 
 struct ShimTrackpadGestures {

--- a/src/TouchVisualizer.cpp
+++ b/src/TouchVisualizer.cpp
@@ -22,7 +22,7 @@ Visualizer::Visualizer() {
 
     const unsigned char* data = cairo_image_surface_get_data(this->cairoSurface);
 
-    this->texture->allocate();
+    this->texture->allocate(Vector2D{2 * TOUCH_POINT_RADIUS, 2 * TOUCH_POINT_RADIUS});
     glBindTexture(GL_TEXTURE_2D, this->texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -56,7 +56,7 @@ void Visualizer::onRender() {
 
     for (auto& finger : this->finger_positions) {
         CBox dmg = boxAroundCenter(finger.second.curr, TOUCH_POINT_RADIUS);
-        g_pHyprOpenGL->renderTexture(this->texture, dmg, {.a = 1.f, .round = 0, .discardActive = true});
+        Render::GL::g_pHyprOpenGL->renderTexture(this->texture, dmg, {.a = 1.f, .round = 0, .discardActive = true});
     }
 }
 

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -1,4 +1,5 @@
 #include <hyprland/src/devices/ITouch.hpp>
+#include <hyprland/src/render/gl/GLTexture.hpp>
 #include <hyprland/src/render/Texture.hpp>
 #include <cairo/cairo.h>
 
@@ -20,7 +21,7 @@ class Visualizer {
     void onTouchMotion(ITouch::SMotionEvent);
 
   private:
-    SP<CTexture> texture = makeShared<CTexture>();
+    SP<ITexture> texture = makeShared<Render::GL::CGLTexture>();
     cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
     const int TOUCH_POINT_RADIUS = 30;

--- a/src/TouchVisualizer.hpp
+++ b/src/TouchVisualizer.hpp
@@ -21,7 +21,7 @@ class Visualizer {
     void onTouchMotion(ITouch::SMotionEvent);
 
   private:
-    SP<ITexture> texture = makeShared<Render::GL::CGLTexture>();
+    SP<Render::ITexture> texture = makeShared<Render::GL::CGLTexture>();
     cairo_surface_t* cairoSurface;
     bool tempDamaged             = false;
     const int TOUCH_POINT_RADIUS = 30;

--- a/src/gestures/test/meson.build
+++ b/src/gestures/test/meson.build
@@ -1,12 +1,17 @@
 doctest = dependency('doctest', required: get_option('tests'))
 if doctest.found()
+  doctest_compile = doctest.partial_dependency(
+    compile_args: true,
+    includes: true,
+  )
+
   test_exe = executable('test-gestures',
     'MockGestureManager.cpp',
     'test.cpp',
     link_with: gestures,
     dependencies: [
       wftouch,
-      doctest
+      doctest_compile
     ]
   )
 

--- a/src/gestures/test/meson.build
+++ b/src/gestures/test/meson.build
@@ -1,5 +1,7 @@
 doctest = dependency('doctest', required: get_option('tests'))
 if doctest.found()
+  # HACK: workaround bad lib flags in nixpkgs doctest:
+  # https://github.com/NixOS/nixpkgs/issues/514722
   doctest_compile = doctest.partial_dependency(
     compile_args: true,
     includes: true,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "TouchVisualizer.hpp"
 #include "globals.hpp"
 #include "version.hpp"
+#include <any>
 #include <expected>
 #include <stdexcept>
 
@@ -62,7 +63,7 @@ static Hyprlang::CParseResult hyprgrassGestureKeyword(const char* LHS, const cha
     if (g_unloading)
         return result;
 
-    CConstVarList data(RHS);
+    Hyprutils::String::CConstVarList data(RHS);
 
     auto maybePattern = parseGesturePattern(data);
     if (!maybePattern) {
@@ -91,17 +92,17 @@ static Hyprlang::CParseResult hyprgrassGestureKeyword(const char* LHS, const cha
     while (true) {
 
         if (data[startDataIdx].starts_with("mod:")) {
-            modMask = g_pKeybindManager->stringToModMask(std::string{data[startDataIdx].substr(4)});
+            modMask = g_pKeybindManager->stringToModMask(std::string(data[startDataIdx].substr(4)));
             startDataIdx++;
             continue;
         } else if (data[startDataIdx].starts_with("scale:")) {
             try {
-                deltaScale = std::clamp(std::stof(std::string{data[startDataIdx].substr(6)}), 0.1F, 10.F);
+                deltaScale = std::clamp(std::stof(std::string(data[startDataIdx].substr(6))), 0.1F, 10.F);
                 startDataIdx++;
                 continue;
             } catch (...) {
                 result.setError(
-                    std::format("Invalid delta scale: {}", std::string{data[startDataIdx].substr(6)}).c_str()
+                    std::format("Invalid delta scale: {}", std::string(data[startDataIdx].substr(6))).c_str()
                 );
                 return result;
             }
@@ -116,9 +117,7 @@ static Hyprlang::CParseResult hyprgrassGestureKeyword(const char* LHS, const cha
 
     if (data[startDataIdx] == "dispatcher")
         resultFromGesture = handler->addGesture(
-            makeUnique<CDispatcherTrackpadGesture>(
-                std::string{data[startDataIdx + 1]}, data.join(",", startDataIdx + 2)
-            ),
+            makeUnique<CDispatcherTrackpadGesture>(std::string(data[startDataIdx + 1]), data.join(",", startDataIdx + 2)),
             pattern.fingers, pattern.direction, modMask, deltaScale, disableInhibit
         );
     else if (data[startDataIdx] == "workspace")
@@ -140,7 +139,7 @@ static Hyprlang::CParseResult hyprgrassGestureKeyword(const char* LHS, const cha
         );
     else if (data[startDataIdx] == "special")
         resultFromGesture = handler->addGesture(
-            makeUnique<CSpecialWorkspaceGesture>(std::string{data[startDataIdx + 1]}), pattern.fingers,
+            makeUnique<CSpecialWorkspaceGesture>(std::string(data[startDataIdx + 1])), pattern.fingers,
             pattern.direction, modMask, deltaScale, disableInhibit
         );
     else if (data[startDataIdx] == "close")
@@ -149,12 +148,12 @@ static Hyprlang::CParseResult hyprgrassGestureKeyword(const char* LHS, const cha
         );
     else if (data[startDataIdx] == "float")
         resultFromGesture = handler->addGesture(
-            makeUnique<CFloatTrackpadGesture>(std::string{data[startDataIdx + 1]}), pattern.fingers, pattern.direction,
+            makeUnique<CFloatTrackpadGesture>(std::string(data[startDataIdx + 1])), pattern.fingers, pattern.direction,
             modMask, deltaScale, disableInhibit
         );
     else if (data[startDataIdx] == "fullscreen")
         resultFromGesture = handler->addGesture(
-            makeUnique<CFullscreenTrackpadGesture>(std::string{data[startDataIdx + 1]}), pattern.fingers,
+            makeUnique<CFullscreenTrackpadGesture>(std::string(data[startDataIdx + 1])), pattern.fingers,
             pattern.direction, modMask, deltaScale, disableInhibit
         );
     else if (data[startDataIdx] == "unset")
@@ -247,7 +246,7 @@ SDispatchResult listInternalBinds(std::string) {
 
 Hyprlang::CParseResult hyrgrassBindKeyword(const char* K, const char* V) {
     std::string v = V;
-    auto vars     = CVarList(v, 4);
+    auto vars     = Hyprutils::String::CVarList(v, 4);
     Hyprlang::CParseResult result;
     struct {
         bool mouse;


### PR DESCRIPTION
This PR fixes the build failure (`ConfigDataValues.hpp: No such file or directory`) caused by recent API changes in Hyprland's `master` branch.

**Main changes:**
1. **Updated include paths**: Fixed the `ConfigDataValues.hpp` missing error to adapt to the latest Hyprland configuration API changes.
2. **Disabled test compilation**: Disabled tests for the `wf-touch` dependency. This fixes a linker error (`cannot find -ldoctest`) on NixOS, as `doctest` is a header-only library and fails to link.

Tested and working on the latest Hyprland commit.