### PR TITLE
fix: build against hyprland legacy config removal (a9902ea)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1784641930,
-        "narHash": "sha256-j1c/65skFvp1WPbHBlAfVWaeCz0Bgwr/WPwIg0H+Ncg=",
+        "lastModified": 1785268604,
+        "narHash": "sha256-voZBWiMj6xIx4rX0bb6TKiTmwPzhBBXZun0LG5Ym9sM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1a3606234c59842340ad9a42baeeffe44a9d6cda",
+        "rev": "924a35735ebadd67c8a078042060fe7e6ba7e060",
         "type": "github"
       },
       "original": {

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -61,6 +61,7 @@ commit_pins = [
     ["a0136d8c04687bb36eb8a28eb9d1ff92aea99704", "d094a3e62f6ecaeb41515982d3e13edefaf8a4e7"], # v0.55.4
     ["79d3a904cd8895fc517488fc8333d3a713f8d4d0", "fb24a0b3397bcf7ad2f11aa819b02eb63a253a8a"],
     ["5c9377c15f85c50648f35ca5a213754f95b93ca0", "36df29f57f94a77b4d5dcf91100f620a46663fa9"], # v0.56.1
+    ["a9902ea65f461af868497c4e74fed798ade0b1b0", "cfb73bc5195e0a35ad77659fbd9c7169169a1550"], # legacy config dropped
     ## DO NOT EDIT THIS LINE: for auto pin script ##
 ]
 

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -9,7 +9,6 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
-#include <hyprland/src/config/legacy/ConfigManager.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/output/Monitor.hpp>
 #include <hyprland/src/pointer/PointerController.hpp>
@@ -21,6 +20,8 @@
 #include <hyprland/src/plugins/PluginSystem.hpp>
 #include <hyprland/src/protocols/core/Compositor.hpp>
 #undef private
+
+#include <hyprutils/string/Numeric.hpp>
 
 #include <algorithm>
 #include <ranges>
@@ -69,33 +70,24 @@ static int handleLongPressTimer(void* data) {
     return 0;
 }
 
-static std::string commaSeparatedCssGaps(const Config::CCssGapData& data) {
-    return std::to_string(data.m_top) + "," + std::to_string(data.m_right) + "," + std::to_string(data.m_bottom) + "," +
-           std::to_string(data.m_left);
-}
-
 static void updateGapsIn(const Config::CCssGapData& newGapsIn) {
     static auto PGAPSINDATA = CConfigValue<Config::IComplexConfigValue>("general:gaps_in");
 
-    if (Config::mgr()->type() == Config::CONFIG_LEGACY) {
-        Config::Legacy::mgr()->parseKeyword("general:gaps_in", commaSeparatedCssGaps(newGapsIn));
-    } else {
-        auto luaMgr = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
+    auto luaMgr = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
 
-        const auto it = luaMgr->m_configValues.find("general.gaps_in");
-        if (it == luaMgr->m_configValues.end()) {
-            Log::logger->log(Log::ERR, "[hyprgrass] lua config 'general.gaps_in' not found");
-            return;
-        }
-
-        auto* gapsInPtr = dynamic_cast<Config::CCssGapData*>(PGAPSINDATA.ptr());
-        // idk why `*gapsInPtr = newGapsIn` doesn't work
-        gapsInPtr->m_bottom = newGapsIn.m_bottom;
-        gapsInPtr->m_top    = newGapsIn.m_top;
-        gapsInPtr->m_left   = newGapsIn.m_left;
-        gapsInPtr->m_right  = newGapsIn.m_right;
-        Config::Supplementary::refresher()->scheduleRefresh(it->second->refreshBits());
+    const auto it = luaMgr->m_configValues.find("general.gaps_in");
+    if (it == luaMgr->m_configValues.end()) {
+        Log::logger->log(Log::ERR, "[hyprgrass] lua config 'general.gaps_in' not found");
+        return;
     }
+
+    auto* gapsInPtr = dynamic_cast<Config::CCssGapData*>(PGAPSINDATA.ptr());
+    // idk why `*gapsInPtr = newGapsIn` doesn't work
+    gapsInPtr->m_bottom = newGapsIn.m_bottom;
+    gapsInPtr->m_top    = newGapsIn.m_top;
+    gapsInPtr->m_left   = newGapsIn.m_left;
+    gapsInPtr->m_right  = newGapsIn.m_right;
+    Config::Supplementary::refresher()->scheduleRefresh(it->second->refreshBits());
 }
 
 GestureManager::GestureManager() : IGestureManager(std::make_unique<HyprLogger>()) {
@@ -291,49 +283,42 @@ bool GestureManager::handleGestureBind(std::string bind, GestureEventType type) 
         if (k->modmask != MODS)
             continue;
 
-        // only legacy config uses "mouse" dispatcher
-        bool useMouseDispatcher = k->mouse && Config::mgr()->type() == Config::CONFIG_LEGACY;
-        const auto DISPATCHER   = g_pKeybindManager->m_dispatchers.find(useMouseDispatcher ? "mouse" : k->handler);
-
         // Should never happen, as we check in the ConfigManager, but oh well
-        if (DISPATCHER == g_pKeybindManager->m_dispatchers.end()) {
-            Log::logger->log(Log::ERR, "Invalid handler in a keybind! (handler {} does not exist)", k->handler);
+        const auto ref = Hyprutils::String::strToNumber<int>(k->arg);
+        if (k->handler != "__lua" || !ref) {
+            Log::logger->log(Log::ERR, "Invalid handler in a keybind! (handler {} is not a lua function)", k->handler);
             continue;
         }
+
+        auto luaMgr = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
 
         switch (type) {
             case GestureEventType::COMPLETED:
                 // mouse dispatchers only trigger on drag begin/end
                 if (!k->mouse) {
                     Log::logger->log(Log::DEBUG, "[hyprgrass] calling dispatcher ({})", bind);
-                    DISPATCHER->second(k->arg);
+                    luaMgr->callLuaFnBind(*ref);
                     found = found || !k->nonConsuming;
                 }
                 break;
 
-            default:
+            default: {
                 if (!k->mouse) {
                     // only mouse actions are considered on drag begin/end
                     continue;
                 }
 
-                if (useMouseDispatcher) {
-                    Log::logger->log(Log::DEBUG, "[hyprgrass] calling mouse dispatcher ({})", bind);
-                    char pressed = type == GestureEventType::DRAG_BEGIN ? '1' : '0';
-                    DISPATCHER->second(pressed + k->arg);
-                    found = found || !k->nonConsuming;
-                } else {
-                    bool pressed          = type == GestureEventType::DRAG_BEGIN;
-                    this->mouseBindActive = pressed;
-                    // yes this is how the lua dispatcher detects key press state
-                    Config::Actions::state()->m_passPressed = static_cast<int>(pressed);
+                bool pressed          = type == GestureEventType::DRAG_BEGIN;
+                this->mouseBindActive = pressed;
+                // yes this is how the lua dispatcher detects key press state
+                Config::Actions::state()->m_passPressed = static_cast<int>(pressed);
 
-                    DISPATCHER->second(k->arg);
+                luaMgr->callLuaFnBind(*ref);
 
-                    Config::Actions::state()->m_passPressed = -1;
+                Config::Actions::state()->m_passPressed = -1;
 
-                    found = found || !k->nonConsuming;
-                }
+                found = found || !k->nonConsuming;
+            }
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
 #include <hyprland/src/managers/input/trackpad/gestures/CloseGesture.hpp>
 #include <hyprland/src/managers/input/trackpad/gestures/CursorZoomGesture.hpp>
-#include <hyprland/src/managers/input/trackpad/gestures/DispatcherGesture.hpp>
 #include <hyprland/src/managers/input/trackpad/gestures/FloatGesture.hpp>
 #include <hyprland/src/managers/input/trackpad/gestures/FullscreenGesture.hpp>
 #include <hyprland/src/managers/input/trackpad/gestures/LuaFunctionGesture.hpp>
@@ -51,10 +50,8 @@ extern "C" {
 #include <lua.h>
 }
 
-const CHyprColor s_pluginColor       = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f, 1.0f};
-const CHyprColor error_color         = {204. / 255.0, 2. / 255.0, 2. / 255.0, 1.0};
-const std::string KEYWORD_HG_BIND    = "hyprgrass-bind";
-const std::string KEYWORD_HG_GESTURE = "hyprgrass-gesture";
+const CHyprColor s_pluginColor = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f, 1.0f};
+const CHyprColor error_color   = {204. / 255.0, 2. / 255.0, 2. / 255.0, 1.0};
 
 static bool g_unloading = false;
 
@@ -68,153 +65,6 @@ void hkOnTouchUp(ITouch::SUpEvent ev, Event::SCallbackInfo& cbinfo) {
 
 void hkOnTouchMove(ITouch::SMotionEvent ev, Event::SCallbackInfo& cbinfo) {
     cbinfo.cancelled = g_pGestureManager->onTouchMove(ev);
-}
-
-static Hyprlang::CParseResult hyprgrassGestureKeyword(const char* LHS, const char* RHS) {
-    Hyprlang::CParseResult result;
-
-    if (g_unloading)
-        return result;
-
-    Hyprutils::String::CConstVarList data(RHS);
-
-    auto maybePattern = parseGesturePattern(data);
-    if (!maybePattern) {
-        result.setError(maybePattern.error().data());
-        return result;
-    }
-    GestureConfig pattern = maybePattern.value();
-
-    int startDataIdx    = 3;
-    uint32_t modMask    = 0;
-    float deltaScale    = 1.F;
-    bool disableInhibit = false;
-
-    const int prefix_size = std::size(KEYWORD_HG_GESTURE);
-    for (const auto arg : std::string(LHS).substr(prefix_size)) {
-        switch (arg) {
-            case 'p':
-                disableInhibit = true;
-                break;
-            default:
-                result.setError("hyprgrass-gesture: invalid flag");
-                return result;
-        }
-    }
-
-    while (true) {
-
-        if (data[startDataIdx].starts_with("mod:")) {
-            modMask = g_pKeybindManager->stringToModMask(std::string(data[startDataIdx].substr(4)));
-            startDataIdx++;
-            continue;
-        } else if (data[startDataIdx].starts_with("scale:")) {
-            try {
-                deltaScale = std::clamp(std::stof(std::string(data[startDataIdx].substr(6))), 0.1F, 10.F);
-                startDataIdx++;
-                continue;
-            } catch (...) {
-                result.setError(
-                    std::format("Invalid delta scale: {}", std::string(data[startDataIdx].substr(6))).c_str()
-                );
-                return result;
-            }
-        }
-
-        break;
-    }
-
-    std::expected<void, std::string> resultFromGesture;
-
-    CTrackpadGestures* handler = g_pShimTrackpadGestures->get(pattern.type);
-
-    if (data[startDataIdx] == "dispatcher")
-        resultFromGesture = handler->addGesture(
-            makeUnique<CDispatcherTrackpadGesture>(
-                std::string(data[startDataIdx + 1]), data.join(",", startDataIdx + 2)
-            ),
-            pattern.fingers(), pattern.direction, modMask, deltaScale, disableInhibit
-        );
-    else if (data[startDataIdx] == "workspace")
-        resultFromGesture = handler->addGesture(
-            makeUnique<CWorkspaceSwipeGesture>(), pattern.fingers(), pattern.direction, modMask, deltaScale,
-            disableInhibit
-        );
-    else if (data[startDataIdx] == "resize")
-        // this handler halves the deltaScale
-        resultFromGesture = handler->addGesture(
-            makeUnique<CResizeTrackpadGesture>(), pattern.fingers(), pattern.direction, modMask, deltaScale * 2,
-            disableInhibit
-        );
-    else if (data[startDataIdx] == "move")
-        // this handler halves the deltaScale
-        resultFromGesture = handler->addGesture(
-            makeUnique<CMoveTrackpadGesture>(), pattern.fingers(), pattern.direction, modMask, deltaScale * 2,
-            disableInhibit
-        );
-    else if (data[startDataIdx] == "special")
-        resultFromGesture = handler->addGesture(
-            makeUnique<CSpecialWorkspaceGesture>(std::string(data[startDataIdx + 1])), pattern.fingers(),
-            pattern.direction, modMask, deltaScale, disableInhibit
-        );
-    else if (data[startDataIdx] == "close")
-        resultFromGesture = handler->addGesture(
-            makeUnique<CCloseTrackpadGesture>(), pattern.fingers(), pattern.direction, modMask, deltaScale,
-            disableInhibit
-        );
-    else if (data[startDataIdx] == "float")
-        resultFromGesture = handler->addGesture(
-            makeUnique<CFloatTrackpadGesture>(std::string(data[startDataIdx + 1])), pattern.fingers(),
-            pattern.direction, modMask, deltaScale, disableInhibit
-        );
-    else if (data[startDataIdx] == "fullscreen")
-        resultFromGesture = handler->addGesture(
-            makeUnique<CFullscreenTrackpadGesture>(std::string(data[startDataIdx + 1])), pattern.fingers(),
-            pattern.direction, modMask, deltaScale, disableInhibit
-        );
-    else if (data[startDataIdx] == "unset")
-        resultFromGesture =
-            handler->removeGesture(pattern.fingers(), pattern.direction, modMask, deltaScale, disableInhibit);
-    else if (data[startDataIdx] == "emulate_touchpad") {
-        const auto fingersStr = data[startDataIdx + 1];
-        uint32_t fingers      = 0;
-
-        try {
-            fingers = std::stoul(std::string(fingersStr));
-        } catch (std::invalid_argument&) {
-            result.setError(
-                std::format("Argument for emulate_touchpad expects a number, got: \"{}\"", fingersStr).c_str()
-            );
-            return result;
-        }
-
-        eTrackpadGestureDirection dir = g_pTrackpadGestures->dirForString(data[startDataIdx + 2]);
-        if (ShimTrackpadGestures::isPinch(pattern.direction) != ShimTrackpadGestures::isPinch(dir)) {
-            if (ShimTrackpadGestures::isPinch(dir)) {
-                result.setError("emulate_touchpad: pinch gestures need to be bound to pinch touch direction");
-            } else {
-                result.setError(
-                    "emulate_touchpad: non-pinch gestures need to be bound to bind to a non-pinch touch direction"
-                );
-            }
-            return result;
-        }
-
-        resultFromGesture = std::expected(handler->addGesture(
-            makeUnique<EmulateTouchpadGesture>(fingers, dir), pattern.fingers(), pattern.direction, modMask, deltaScale,
-            disableInhibit
-        ));
-    } else {
-        result.setError(std::format("Invalid gesture: {}", data[startDataIdx]).c_str());
-        return result;
-    }
-
-    if (!resultFromGesture) {
-        result.setError(resultFromGesture.error().c_str());
-        return result;
-    }
-
-    return result;
 }
 
 static bool luaTableGetBool(lua_State* L, int idx, std::string_view key) {
@@ -671,56 +521,6 @@ SDispatchResult listInternalBinds(std::string) {
     return SDispatchResult{.success = true};
 }
 
-Hyprlang::CParseResult hyrgrassBindKeyword(const char* K, const char* V) {
-    std::string v = V;
-    auto vars     = Hyprutils::String::CVarList(v, 4);
-    Hyprlang::CParseResult result;
-    struct {
-        bool mouse;
-        bool locked;
-    } flags = {};
-
-    if (vars.size() < 3) {
-        result.setError("must have at least 3 fields: <empty>, <gesture_event>, <dispatcher>, [args]");
-        return result;
-    }
-
-    uint32_t modMask = g_pKeybindManager->stringToModMask(vars[0]);
-
-    const int prefix_size = std::size(KEYWORD_HG_BIND);
-    for (char c : std::string(K).substr(prefix_size)) {
-        switch (c) {
-            case 'm':
-                flags.mouse = true;
-                break;
-            case 'l':
-                flags.locked = true;
-                break;
-            default:
-                HyprlandAPI::addNotification(
-                    PHANDLE, std::string("ignoring invalid hyprgrass-bind flag: ") + c, error_color, 5000
-                );
-        }
-    }
-
-    const auto key            = vars[1];
-    const auto dispatcher     = flags.mouse ? "mouse" : vars[2];
-    const auto dispatcherArgs = flags.mouse ? vars[2] : vars[3];
-
-    g_pGestureManager->internalBinds.emplace_back(
-        makeShared<SKeybind>(SKeybind{
-            .key     = key,
-            .modmask = modMask,
-            .handler = dispatcher,
-            .arg     = dispatcherArgs,
-            .locked  = flags.locked,
-            .mouse   = flags.mouse,
-        })
-    );
-
-    return result;
-}
-
 std::shared_ptr<HOOK_CALLBACK_FN> g_pTouchDownHook;
 std::shared_ptr<HOOK_CALLBACK_FN> g_pTouchUpHook;
 std::shared_ptr<HOOK_CALLBACK_FN> g_pTouchMoveHook;
@@ -733,34 +533,17 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
-    if (Config::mgr()->type() == Config::CONFIG_LEGACY) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        g_config = makeUnique<Cfg>("touch_gestures");
-        HyprlandAPI::addConfigKeyword(
-            PHANDLE, KEYWORD_HG_BIND, hyrgrassBindKeyword, Hyprlang::SHandlerOptions{.allowFlags = true}
-        );
-        HyprlandAPI::addConfigKeyword(
-            PHANDLE, KEYWORD_HG_GESTURE, hyprgrassGestureKeyword, Hyprlang::SHandlerOptions{true}
-        );
-
-        // legacy-only options
-        HyprlandAPI::addConfigValueV2(PHANDLE, g_config->workspaceSwipeFingers);
-        HyprlandAPI::addConfigValueV2(PHANDLE, g_config->workspaceSwipeEdge);
-#pragma GCC diagnostic pop
-    } else {
-        g_config = makeUnique<Cfg>("hyprgrass");
-        HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "bind", newBind);
-        HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "gesture", newGesture);
-        HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "debug_binds", [](lua_State*) {
-            listInternalBinds("");
-            return 0;
-        });
-        HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "debug_gestures", [](lua_State*) {
-            g_pShimTrackpadGestures->listGestures();
-            return 0;
-        });
-    }
+    g_config = makeUnique<Cfg>("hyprgrass");
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "bind", newBind);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "gesture", newGesture);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "debug_binds", [](lua_State*) {
+        listInternalBinds("");
+        return 0;
+    });
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprgrass", "debug_gestures", [](lua_State*) {
+        g_pShimTrackpadGestures->listGestures();
+        return 0;
+    });
 
     HyprlandAPI::addConfigValueV2(PHANDLE, g_config->longPressDelay);
     HyprlandAPI::addConfigValueV2(PHANDLE, g_config->edgeMargin);


### PR DESCRIPTION
Support for legacy config was dropped in hyprland. I removed the branching logic I could find so that hyprgrass builds on ~~0.56~~ (edit: the drop happened on `main` only. Still unreleased as of now.)