### PR TITLE
Replace deprecated lua function

### DIFF
--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -297,7 +297,7 @@ bool GestureManager::handleGestureBind(std::string bind, GestureEventType type) 
                 // mouse dispatchers only trigger on drag begin/end
                 if (!k->mouse) {
                     Log::logger->log(Log::DEBUG, "[hyprgrass] calling dispatcher ({})", bind);
-                    luaMgr->callLuaFnBind(*ref);
+                    luaMgr->callLuaFn(*ref);
                     found = found || !k->nonConsuming;
                 }
                 break;
@@ -313,7 +313,7 @@ bool GestureManager::handleGestureBind(std::string bind, GestureEventType type) 
                 // yes this is how the lua dispatcher detects key press state
                 Config::Actions::state()->m_passPressed = static_cast<int>(pressed);
 
-                luaMgr->callLuaFnBind(*ref);
+                luaMgr->callLuaFn(*ref);
 
                 Config::Actions::state()->m_passPressed = -1;
 


### PR DESCRIPTION
Replaces deprecated `callLuaFnBind` function with `callLuaFn`. Fixes compilation errors on `hyprpm update`

Confirmed compiles and functions correctly now
<img width="480" height="301" alt="hyprgrass-proof" src="https://github.com/user-attachments/assets/06f25ec1-139b-4342-93ad-b6dcf9cfcb1e" />
