### PR TITLE
fix(gestures): compare drag distance, not dx^2 + 2dy

### DIFF
--- a/src/gestures/Actions.cpp
+++ b/src/gestures/Actions.cpp
@@ -62,7 +62,7 @@ MultiFingerTap::update_state(const wf::touch::gesture_state_t& state, const wf::
     if (event.type == wf::touch::EVENT_TYPE_MOTION) {
         for (const auto& finger : state.fingers) {
             const auto delta = finger.second.delta();
-            if (delta.x * delta.x + delta.y + delta.y > this->base_threshold / *this->sensitivity) {
+            if (glm::length(delta) > this->base_threshold / *this->sensitivity) {
                 return wf::touch::ACTION_STATUS_CANCELLED;
             }
         }
@@ -81,7 +81,7 @@ LongPress::update_state(const wf::touch::gesture_state_t& state, const wf::touch
         case wf::touch::EVENT_TYPE_MOTION:
             for (const auto& finger : state.fingers) {
                 const auto delta = finger.second.delta();
-                if (delta.x * delta.x + delta.y + delta.y > this->base_threshold / *this->sensitivity) {
+                if (glm::length(delta) > this->base_threshold / *this->sensitivity) {
                     return wf::touch::ACTION_STATUS_CANCELLED;
                 }
             }

--- a/src/gestures/test/test.cpp
+++ b/src/gestures/test/test.cpp
@@ -285,6 +285,23 @@ TEST_CASE("Multi-finger Tap: finger moved too much") {
     ProcessEvents(gm, {.type = ExpectResultType::CANCELLED}, events);
 }
 
+// As above, but moving along -y rather than +x.
+TEST_CASE("Multi-finger Tap: finger moved too much upward") {
+    log_start_of_test();
+    auto gm = CMockGestureManager::newCompletedGestureOnlyHandler();
+    gm.addMultiFingerTap(SWIPE_INCORRECT_DRAG_TOLERANCE, &SENSITIVITY, &LONG_PRESS_DELAY);
+
+    const std::vector<TouchEvent> events{
+        Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {450, 290}},
+        Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 105, 1, {500, 300}},
+        Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 110, 2, {550, 290}},
+        // 110px straight up, past the 100px threshold
+        Ev{wf::touch::EVENT_TYPE_MOTION, 120, 1, {500, 190}},
+    };
+
+    ProcessEvents(gm, {.type = ExpectResultType::CANCELLED}, events);
+}
+
 TEST_CASE("Multi-finger Tap: non-consuming gesture does not send cancel to windows") {
     log_start_of_test();
     auto gm = CMockGestureManager::newNonConsumingHandler();
@@ -390,6 +407,24 @@ TEST_CASE("Long press and drag: cancelled due to too much movement") {
         Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 105, 1, {500, 300}},
         Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 110, 2, {550, 290}},
         Ev{wf::touch::EVENT_TYPE_MOTION, 200, 1, {650, 290}},
+    };
+
+    ProcessEvents(gm, {.type = ExpectResultType::CANCELLED}, events);
+}
+
+// The case above moves almost purely along +x, which any expression involving delta.x
+// catches. This one moves along -y, where the sign of the movement matters.
+TEST_CASE("Long press and drag: cancelled due to too much upward movement") {
+    log_start_of_test();
+    auto gm = CMockGestureManager::newDragHandler();
+    gm.addLongPress(SWIPE_THRESHOLD, &SENSITIVITY, &LONG_PRESS_DELAY);
+
+    const std::vector<TouchEvent> events{
+        Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 100, 0, {450, 290}},
+        Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 105, 1, {500, 300}},
+        Ev{wf::touch::EVENT_TYPE_TOUCH_DOWN, 110, 2, {550, 290}},
+        // 160px straight up, past the 150px threshold
+        Ev{wf::touch::EVENT_TYPE_MOTION, 200, 1, {500, 140}},
     };
 
     ProcessEvents(gm, {.type = ExpectResultType::CANCELLED}, events);


### PR DESCRIPTION
## The bug

`LongPress::update_state` and `MultiFingerTap::update_state` both decide whether the finger has slipped too far to still count as a press:

```cpp
if (delta.x * delta.x + delta.y + delta.y > this->base_threshold / *this->sensitivity)
    return wf::touch::ACTION_STATUS_CANCELLED;
```

`delta.y + delta.y` should be `delta.y * delta.y`.

## Why it matters: upward drags are never cancelled

As written the expression is `dx² + 2·dy`. Beyond mixing squared and unsquared units, it isn't symmetric in `y` — `dy` is negative for upward movement, so moving up *subtracts*. A near-vertical upward drag can therefore never reach a positive threshold, the long press is never cancelled, and it completes on the `long_press_delay` timer in the middle of the drag. The completion callback in `addLongPress` then reaches `cancelTouchEventsOnAllWindows()`, which sets `inhibitTouchEvents`, and every remaining touch-move is swallowed until liftoff.

On a touchscreen with natural scrolling, dragging upward is how you scroll down. So the user-visible symptom is that scrolling dies ~400 ms in, every time, while horizontal drags feel fine — which makes it look like a driver or hardware fault rather than a gesture bug.

## The fix

Use the Euclidean distance, which is the convention already used a few lines above in the same file, in `CMultiAction::update_state`:

```cpp
if (glm::length(delta) > this->base_threshold / *this->sensitivity)
```

`<glm/geometric.hpp>` is already included, so nothing else changes.

## This shifts effective tolerances — worth a sanity check on the constant

Because the old expression wasn't a distance in *any* direction, correcting it moves the thresholds everywhere, not just upward. At the default `sensitivity = 1.0`, with the `SWIPE_THRESHOLD` of 150 that `addLongPress` is called with:

| Finger moves | Cancels before | Cancels after |
| --- | --- | --- |
| Horizontally | 12.2 px (`dx² > 150`) | 150 px |
| Downward | 75 px (`2·dy > 150`) | 150 px |
| Upward | never | 150 px |

So long-press becomes noticeably more slip-tolerant than it is today. That may not be what you want — 150 px is a lot of travel for a gesture that means "held still". This is the same question as your existing `// TODO: should I use SWIPE_INCORRECT_DRAG_TOLERANCE instead?` on the `addLongPress` call.

I've deliberately left the constant alone so the fix isn't blocked on a taste call. Happy to follow up with whatever value you prefer, or fold it into this PR if you'd rather decide now.

## Tests

One regression case per affected action. Both fail on current `main` and pass with the fix; the other 31 cases are unaffected either way.

There is already a `Long press and drag: cancelled due to too much movement`, but it moves a finger by `(+150, -10)` — almost pure `+x`, where `dx²` alone is 22500 and swamps the threshold, so it passes with or without the bug. Nothing in the existing suite moves in a direction where `dy` dominates, which is why this went unnoticed. Note that case now passes by 0.33 px (`√(150² + 10²)` = 150.33 against a threshold of 150), so it may be worth widening independently of this PR.

## Unrelated observation: two assertions already fail on `main`

While setting up, I noticed that a pristine `main` (404280f) reports two failing assertions:

```
../src/gestures/test/test.cpp:86:  CHECK( std::abs(got - expect.progress) < 1e-5 ) is NOT correct!
../src/gestures/test/test.cpp:142: CHECK( gm.eventForwardingInhibited() ) is NOT correct!

[doctest] test cases:  31 | 31 passed | 0 failed | 0 skipped
[doctest] assertions: 542 | 540 passed | 2 failed |
[doctest] Status: SUCCESS!
```

doctest counts them as failed assertions but attributes them to no test case, reports `SUCCESS`, and exits 0 — so CI stays green. Nothing to do with this change; flagging it since it's invisible from the outside.

---

Diagnosed and written with AI assistance. Verified on hardware — a Wacom HID 5400 touchscreen under Hyprland 0.56.2: pristine `main` reproduces the freeze, and a build of this branch does not, with stationary long-press still firing correctly.
