### PR TITLE
Port to Hyprland 0.56.2

### DIFF
--- a/examples/hyprgrass-backlight/main.cpp
+++ b/examples/hyprgrass-backlight/main.cpp
@@ -13,7 +13,7 @@
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/input/trackpad/GestureTypes.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
-#include <hyprland/src/keybinds/Resolver.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/version.h>
 
@@ -79,7 +79,7 @@ static Hyprlang::CParseResult gestureKeyword(const char* LHS, const char* RHS) {
     eTrackpadGestureDirection direction = g_pTrackpadGestures->dirForString(data[1]);
 
     int startDataIdx    = 2;
-    Input::ModifierMask modMask = Input::HL_MODIFIER_NONE;
+    uint32_t modMask = 0u;
     float deltaScale    = 1.F;
     bool disableInhibit = false;
 
@@ -98,7 +98,7 @@ static Hyprlang::CParseResult gestureKeyword(const char* LHS, const char* RHS) {
     while (true) {
 
         if (data[startDataIdx].starts_with("mod:")) {
-            modMask = Keybinds::modMaskFromString(std::string(data[startDataIdx].substr(4)));
+            modMask = g_pKeybindManager->stringToModMask(std::string(data[startDataIdx].substr(4)));
             startDataIdx++;
             continue;
         } else if (data[startDataIdx].starts_with("scale:")) {

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -63,6 +63,7 @@ commit_pins = [
     ["5c9377c15f85c50648f35ca5a213754f95b93ca0", "36df29f57f94a77b4d5dcf91100f620a46663fa9"], # v0.56.1
     ["a9902ea65f461af868497c4e74fed798ade0b1b0", "cfb73bc5195e0a35ad77659fbd9c7169169a1550"], # legacy config dropped
     ["af0d014cb26f536d8cb7cab2b9d5784f69767c8a", "37d6f0ad4eeee01f8579da9a803a62208f4e11ae"], # Keybind and view refactors
+    ["efb50993780079460b0cbed1363e2166a2de1d9f", "2db328fe2b3e8b6a2eee5d17a91ff1ca4177719f"], # v0.56.2
     ## DO NOT EDIT THIS LINE: for auto pin script ##
 ]
 

--- a/src/GestureManager.cpp
+++ b/src/GestureManager.cpp
@@ -11,10 +11,9 @@
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
 #include <hyprland/src/config/supplementary/propRefresher/PropRefresher.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
-#include <hyprland/src/desktop/view/window/WindowPresentation.hpp>
 #include <hyprland/src/managers/SeatManager.hpp>
 #include <hyprland/src/managers/fullscreen/FullscreenController.hpp>
-#include <hyprland/src/keybinds/Manager.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/layout/LayoutManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/input/UnifiedWorkspaceSwipeGesture.hpp>
@@ -194,9 +193,8 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
                         real.height + 2 * BORDER_GRAB_AREA
                     };
 
-                    bool notInRealWindow =
-                        !real.containsPoint(touchPos) || w->presentation().isInCurvedCorner(touchPos.x, touchPos.y);
-                    bool onTiledGap = !w->isFloating() && !Fullscreen::controller()->isFullscreen(w) && notInRealWindow;
+                    bool notInRealWindow = !real.containsPoint(touchPos) || w->isInCurvedCorner(touchPos.x, touchPos.y);
+                    bool onTiledGap = !w->m_isFloating && !Fullscreen::controller()->isFullscreen(w) && notInRealWindow;
                     bool inGrabArea = notInRealWindow && grab.containsPoint(touchPos);
 
                     if ((onTiledGap || inGrabArea) && !w->hasPopupAt(touchPos)) {
@@ -245,18 +243,18 @@ bool GestureManager::handleDragGesture(const DragGestureEvent& gev) {
 }
 
 // Adapt new hyprland keybind type back to the old one (hacky compat for now)
-static std::vector<SP<SKeybind>> keybindsToSKeybinds() {
-    std::vector<SP<SKeybind>> binds;
-    for (const auto& k : Keybinds::mgr()->registry().binds())
-        binds.emplace_back(makeShared<SKeybind>(SKeybind{
-            .key          = k->metadata().displayKey,
-            .handler      = k->metadata().handler,
-            .arg          = k->metadata().argument,
-            .displayKey   = k->metadata().displayKey,
-            .mouse        = k->hasFlag(Keybinds::BIND_FLAG_MOUSE),
-            .locked       = k->hasFlag(Keybinds::BIND_FLAG_LOCKED),
-            .nonConsuming = k->hasFlag(Keybinds::BIND_FLAG_NON_CONSUMING),
-            .modmask      = static_cast<uint32_t>(k->modifierMask()),
+static std::vector<SP<SHgKeybind>> keybindsToSKeybinds() {
+    std::vector<SP<SHgKeybind>> binds;
+    for (const auto& k : g_pKeybindManager->m_keybinds)
+        binds.emplace_back(makeShared<SHgKeybind>(SHgKeybind{
+            .key          = k->displayKey,
+            .handler      = k->handler,
+            .arg          = k->arg,
+            .displayKey   = k->displayKey,
+            .mouse        = k->mouse,
+            .locked       = k->locked,
+            .nonConsuming = k->nonConsuming,
+            .modmask      = k->modmask,
         }));
     return binds;
 }
@@ -792,7 +790,7 @@ void GestureManager::touchBindDispatcher(std::string args) {
     const auto dispatcherArgs = trim(argsSplit[3]);
 
     this->internalBinds.emplace_back(
-        makeShared<SKeybind>(SKeybind{
+        makeShared<SHgKeybind>(SHgKeybind{
             .key     = key,
             .handler = dispatcher,
             .arg     = dispatcherArgs,

--- a/src/GestureManager.hpp
+++ b/src/GestureManager.hpp
@@ -13,7 +13,7 @@
 #include <hyprland/src/config/values/types/IntValue.hpp>
 #include <hyprland/src/config/values/types/StringValue.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
-#include <hyprland/src/keybinds/Manager.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
 #include <hyprland/src/protocols/core/Seat.hpp>
 #undef private
@@ -25,7 +25,7 @@ enum class GestureEventType {
 };
 
 // compat adapter
-struct SKeybind {
+struct SHgKeybind {
     std::string key;
     std::string handler;
     std::string arg;
@@ -87,7 +87,7 @@ struct Cfg {
 class GestureManager final : public IGestureManager {
   public:
     uint32_t long_press_next_trigger_time;
-    std::vector<SP<SKeybind>> internalBinds;
+    std::vector<SP<SHgKeybind>> internalBinds;
 
     GestureManager();
     ~GestureManager();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,7 @@
 #include <hyprland/src/config/lua/bindings/LuaBindingsInternal.hpp>
 #include <hyprland/src/debug/log/Logger.hpp>
 #include <hyprland/src/event/EventBus.hpp>
-#include <hyprland/src/keybinds/Manager.hpp>
-#include <hyprland/src/keybinds/Resolver.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/input/trackpad/GestureTypes.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
@@ -137,7 +136,7 @@ int newBind(lua_State* L) {
             L, "hyprgrass.bind: expected a table { mod, pattern, dispatcher, args }"
         );
 
-    SKeybind bind{};
+    SHgKeybind bind{};
 
     // Parse the table structure
     {
@@ -149,7 +148,7 @@ int newBind(lua_State* L) {
                 return Config::Lua::Bindings::Internal::configError(L, "hyprgrass.bind: mod must be a string");
 
             const char* modStr = lua_tostring(L, -1);
-            bind.modmask       = static_cast<uint32_t>(Keybinds::modMaskFromString(modStr));
+            bind.modmask       = static_cast<uint32_t>(g_pKeybindManager->stringToModMask(modStr));
         }
     }
 
@@ -195,7 +194,7 @@ int newBind(lua_State* L) {
     bind.locked       = luaTableGetBool(L, 1, "locked");
     bind.nonConsuming = luaTableGetBool(L, 1, "non_consuming");
 
-    g_pGestureManager->internalBinds.emplace_back(makeShared<SKeybind>(bind));
+    g_pGestureManager->internalBinds.emplace_back(makeShared<SHgKeybind>(bind));
 
     return 0;
 }
@@ -366,8 +365,7 @@ int newGesture(lua_State* L) {
     }
 
     auto maybeMod             = modResult.value();
-    Input::ModifierMask modMask =
-        maybeMod ? Keybinds::modMaskFromString(std::string{maybeMod.value()}) : Input::ModifierMask(0u);
+    uint32_t modMask = maybeMod ? g_pKeybindManager->stringToModMask(std::string{maybeMod.value()}) : 0u;
 
     auto maybeScaleResult = luaTableMaybeGetFloat(L, 1, "scale");
     if (!maybeScaleResult) {


### PR DESCRIPTION
Adapt to the keybinds manager refactor and other 0.56 API changes:

- keybinds/Manager.hpp and keybinds/Resolver.hpp no longer exist; use managers/KeybindManager.hpp (g_pKeybindManager)
- Enumerate keybinds from g_pKeybindManager->m_keybinds instead of Keybinds::mgr()->registry().binds()
- Read SKeybind fields directly (displayKey/handler/arg/modmask/mouse/ locked/nonConsuming) instead of metadata()/hasFlag()
- Replace Keybinds::modMaskFromString() with g_pKeybindManager->stringToModMask()
- Rename hyprgrass's local SKeybind struct to SHgKeybind to avoid a name collision with Hyprland's now-global SKeybind
- WindowPresentation.hpp removed; use CWindow::isInCurvedCorner() directly
- Window::isFloating() renamed to m_isFloating
- Use uint32_t for modMask (Input::ModifierMask no longer exists)
- Add hyprpm commit_pin for Hyprland 0.56.2